### PR TITLE
bugfix: add Edit server URL button to error screen (closes #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ To get added, **message [@Paladin173](https://github.com/Paladin173) your Gmail 
 
 Once added, the app will appear in the Play Store for you to install and receive automatic updates.
 
-Current pre-release version: `v0.1.7`.
+Current pre-release version: `v0.1.8`.
 
 Current Android build metadata:
 
-- Version name: `0.1.7`
-- Version code: `8`
+- Version name: `0.1.8`
+- Version code: `9`
 - Application ID: `com.hermeswebui.android`
 - Compile/target SDK: `37`
 
@@ -100,7 +100,7 @@ Requirements:
 - Cold-start restore keeps the active Hermes session/workspace route when the app process is restarted, with a WebUI-origin-scoped workspace-button recovery fallback that reloads the last known in-app session route if the panel is tapped from a blank root state
 - Server health probing on WebView errors to distinguish server-down from content errors
 - First-run settings flow for the Hermes WebUI URL; the dashboard URL is managed only by WebUI Settings > System
-- Back handling, pull-to-refresh, loading, offline, and error states
+- Back handling, pull-to-refresh, loading, offline, and error states, including direct server-URL recovery from the native error screen
 
 ### 🔌 Android integration
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -151,6 +151,8 @@ workflow changes should be made in Hermes WebUI instead.
 | REL-008 | 2026-06-23 | Release | Updated Android app version metadata to `0.1.6` with `versionCode` 7; narrowed GitHub release automation to build and publish only `hermes-webui-v0.1.6-github.apk`, with tag/version validation before release upload |
 | REL-009 | 2026-06-23 | Release | Added a separate manual GitHub Actions workflow (`.github/workflows/play-aab.yml`) that builds/signs a release AAB, renames it to `hermes-webui-v<version>.aab`, and uploads it as an artifact for manual Google Play Console upload until automated Play publishing is wired |
 | REL-010 | 2026-06-22 | Release | Incremented Android app version metadata to `0.1.7` with `versionCode` 8 and documented release-note scoping so app releases summarize runtime/app changes only (excluding workflow-only and docs-only updates) |
+| BUG-013 | 2026-06-22 | UI | Fixed Issue 8 by adding an **Edit server URL** recovery action to the native error screen so users can reopen Settings and correct a bad saved Hermes server URL without clearing app data |
+| REL-011 | 2026-06-22 | Release | Updated Android app version metadata to `0.1.8` with `versionCode` 9 |
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.io.File
 import java.util.Properties
 
-val appVersionName = "0.1.7"
+val appVersionName = "0.1.8"
 val githubReleaseArtifactName = "hermes-webui-v$appVersionName-github"
 
 val keystoreProperties = Properties().apply {
@@ -96,7 +96,7 @@ extensions.configure<ApplicationExtension>("android") {
         applicationId = "com.hermeswebui.android"
         minSdk = 26
         targetSdk = 37
-        versionCode = 8
+        versionCode = 9
         versionName = appVersionName
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -163,7 +163,13 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.truth)
 
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    androidTestImplementation(libs.truth)
+
     debugImplementation(libs.androidx.compose.ui.tooling)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 }
 
 fun copyFirstExistingArtifact(candidates: List<File>, target: File) {

--- a/app/src/androidTest/java/com/hermeswebui/android/ui/web/WebShellTest.kt
+++ b/app/src/androidTest/java/com/hermeswebui/android/ui/web/WebShellTest.kt
@@ -1,0 +1,91 @@
+package com.hermeswebui.android.ui.web
+
+import android.webkit.WebView
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WebShellTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun errorScreen_showsEditServerUrlButton() {
+        composeTestRule.setContent {
+            val context = LocalContext.current
+            val fakeWebView = remember { WebView(context) }
+            WebShell(
+                webView = fakeWebView,
+                isLoading = false,
+                hasLoadedContent = false,
+                isOffline = false,
+                errorMessage = "Connection refused",
+                onRefresh = {},
+                onRetry = {},
+                onOpenExternal = {},
+                onOpenSettings = {}
+            )
+        }
+
+        composeTestRule.onNodeWithText("Edit server URL").assertIsDisplayed()
+    }
+
+    @Test
+    fun errorScreen_clickEditServerUrl_invokesOnOpenSettings() {
+        var settingsOpened = false
+
+        composeTestRule.setContent {
+            val context = LocalContext.current
+            val fakeWebView = remember { WebView(context) }
+            WebShell(
+                webView = fakeWebView,
+                isLoading = false,
+                hasLoadedContent = false,
+                isOffline = false,
+                errorMessage = "Connection refused",
+                onRefresh = {},
+                onRetry = {},
+                onOpenExternal = {},
+                onOpenSettings = { settingsOpened = true }
+            )
+        }
+
+        composeTestRule.onNodeWithText("Edit server URL").performClick()
+
+        assertThat(settingsOpened).isTrue()
+    }
+
+    @Test
+    fun noError_editServerUrlButton_isNotDisplayed() {
+        composeTestRule.setContent {
+            val context = LocalContext.current
+            val fakeWebView = remember { WebView(context) }
+            WebShell(
+                webView = fakeWebView,
+                isLoading = false,
+                hasLoadedContent = true,
+                isOffline = false,
+                errorMessage = null,
+                onRefresh = {},
+                onRetry = {},
+                onOpenExternal = {},
+                onOpenSettings = {}
+            )
+        }
+
+        composeTestRule.onAllNodesWithText("Edit server URL").assertCountEquals(0)
+    }
+}
+

--- a/app/src/main/java/com/hermeswebui/android/MainActivity.kt
+++ b/app/src/main/java/com/hermeswebui/android/MainActivity.kt
@@ -406,7 +406,8 @@ class MainActivity : ComponentActivity() {
                         errorMessage = uiState.errorMessage,
                         onRefresh = onReload,
                         onRetry = onReload,
-                        onOpenExternal = onOpenExternal
+                        onOpenExternal = onOpenExternal,
+                        onOpenSettings = { viewModel.openSettings() }
                     )
                     SnackbarHost(hostState = snackbarHostState)
                 }

--- a/app/src/main/java/com/hermeswebui/android/ui/web/WebShell.kt
+++ b/app/src/main/java/com/hermeswebui/android/ui/web/WebShell.kt
@@ -18,8 +18,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import com.hermeswebui.android.R
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -31,7 +33,8 @@ fun WebShell(
     errorMessage: String?,
     onRefresh: () -> Unit,
     onRetry: () -> Unit,
-    onOpenExternal: () -> Unit
+    onOpenExternal: () -> Unit,
+    onOpenSettings: () -> Unit
 ) {
     val pullRefreshState = rememberPullRefreshState(
         refreshing = isLoading,
@@ -84,6 +87,9 @@ fun WebShell(
                 }
                 Button(modifier = Modifier.padding(top = 8.dp), onClick = onOpenExternal) {
                     Text("Open in browser")
+                }
+                Button(modifier = Modifier.padding(top = 8.dp), onClick = onOpenSettings) {
+                    Text(stringResource(R.string.action_edit_server_url))
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="app_name">Hermes WebUI</string>
     <string name="default_server_url">https://hermes.example.com</string>
     <string name="default_dashboard_url"></string>
+    <string name="action_edit_server_url">Edit server URL</string>
 </resources>

--- a/app/src/test/java/com/hermeswebui/android/MainViewModelTest.kt
+++ b/app/src/test/java/com/hermeswebui/android/MainViewModelTest.kt
@@ -75,6 +75,46 @@ class MainViewModelTest {
     }
 
     @Test
+    fun `openSettings sets isSettingsVisible`() {
+        val store = FakeSettingsStore()
+        val viewModel = MainViewModel(store, defaultServerUrl, defaultDashboardUrl)
+
+        viewModel.openSettings()
+
+        assertThat(viewModel.uiState.value.isSettingsVisible).isTrue()
+    }
+
+    @Test
+    fun `openSettings from error state shows settings without clearing error`() {
+        val store = FakeSettingsStore()
+        val viewModel = MainViewModel(store, defaultServerUrl, defaultDashboardUrl)
+
+        viewModel.onPageStarted(defaultServerUrl)
+        viewModel.onPageError("Connection refused", isOffline = true)
+        viewModel.openSettings()
+
+        val state = viewModel.uiState.value
+        assertThat(state.isSettingsVisible).isTrue()
+        assertThat(state.errorMessage).isEqualTo("Connection refused")
+    }
+
+    @Test
+    fun `saveAppUrls from error state clears error and starts loading new url`() {
+        val store = FakeSettingsStore()
+        val viewModel = MainViewModel(store, defaultServerUrl, defaultDashboardUrl)
+
+        viewModel.onPageStarted(defaultServerUrl)
+        viewModel.onPageError("Connection refused", isOffline = true)
+        viewModel.saveAppUrls("https://next.example.com", defaultDashboardUrl)
+
+        val state = viewModel.uiState.value
+        assertThat(state.errorMessage).isNull()
+        assertThat(state.isSettingsVisible).isFalse()
+        assertThat(state.isLoading).isTrue()
+        assertThat(state.currentUrl).isEqualTo("https://next.example.com")
+    }
+
+    @Test
     fun `reset session resets loaded content state`() {
         val store = FakeSettingsStore()
         val viewModel = MainViewModel(store, defaultServerUrl, defaultDashboardUrl)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ securityCrypto = "1.1.0"
 materialComponents = "1.14.0"
 junit = "4.13.2"
 truth = "1.4.5"
+androidxTestExtJunit = "1.2.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -29,6 +30,9 @@ androidx-security-crypto = { group = "androidx.security", name = "security-crypt
 google-material = { group = "com.google.android.material", name = "material", version.ref = "materialComponents" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExtJunit" }
+androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
Fixes #8 - wrong server URL recovery.
### Problem
Users who configured an incorrect server URL were stuck on the error screen with only **Retry** and **Open in browser** options — no way to fix the URL without force-closing the app.
### Fix
Added an **Edit server URL** button to the WebView error screen that opens the Settings bottom sheet directly.
### Changes
- **WebShell.kt**: Added \onOpenSettings\ callback parameter and an 'Edit server URL' button to the error screen UI
- **MainActivity.kt**: Wired the \onOpenSettings\ callback through \AppContent\ to call \iewModel.openSettings()\
- **strings.xml**: Added localization string \rror_edit_server_url\ for the new button label
### Testing
- All unit tests pass
- Debug APK builds successfully