### PR TITLE
BUG-015: auto-retry reconnect after transient server restart

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -156,6 +156,7 @@ workflow changes should be made in Hermes WebUI instead.
 | BUG-014 | 2026-06-22 | Android compatibility | Fixed WebUI update-notification generated summaries rendering as a clipped/non-scrollable sliver in Android WebView by restoring vertical page scrolling and re-capping the update summary panel's `max-height: min(34vh, 260px)` with the measured viewport height because Android WebView was collapsing that `vh` max-height to `0px` |
 | REL-012 | 2026-06-23 | Release | Wired `.github/workflows/play-aab.yml` to upload the signed `hermes-webui-v<version>.aab` artifact to the Google Play internal testing track using the configured Play service-account secret |
 | REL-013 | 2026-06-23 | Release | Split GitHub APK builds into a separate `github` release build type with `applicationIdSuffix = ".github"` and `versionNameSuffix = "-github"` so sideloaded GitHub builds can install beside Google Play builds |
+| BUG-015 | 2026-06-23 | WebView | Fixed Issue 9: added bounded auto-retry loop on server error — polls `/api/status` with 1 s → 2 s → 4 s → 10 s cap backoff for up to 60 s, auto-reloads when server comes back, shows "Reconnecting…" on the error screen, cancels cleanly on manual Retry / new navigation / settings save |
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -173,6 +173,7 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)
+    testImplementation(libs.kotlinx.coroutines.test)
 
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.test.ext.junit)

--- a/app/src/main/java/com/hermeswebui/android/MainActivity.kt
+++ b/app/src/main/java/com/hermeswebui/android/MainActivity.kt
@@ -385,6 +385,13 @@ class MainActivity : ComponentActivity() {
             snackbarHostState.showSnackbar(banner)
         }
 
+        // Auto-reload when the retry loop detects the server is back.
+        LaunchedEffect(Unit) {
+            viewModel.autoReloadEvent.collect {
+                webView.reload()
+            }
+        }
+
         BackHandler {
             when {
                 uiState.isSettingsVisible -> viewModel.closeSettings()
@@ -408,9 +415,13 @@ class MainActivity : ComponentActivity() {
                         isLoading = uiState.isLoading,
                         hasLoadedContent = uiState.hasLoadedContent,
                         isOffline = uiState.isOffline,
+                        isReconnecting = uiState.isReconnecting,
                         errorMessage = uiState.errorMessage,
                         onRefresh = onReload,
-                        onRetry = onReload,
+                        onRetry = {
+                            viewModel.cancelAutoRetry()
+                            onReload()
+                        },
                         onOpenExternal = onOpenExternal,
                         onOpenSettings = { viewModel.openSettings() }
                     )

--- a/app/src/main/java/com/hermeswebui/android/MainActivity.kt
+++ b/app/src/main/java/com/hermeswebui/android/MainActivity.kt
@@ -341,7 +341,14 @@ class MainActivity : ComponentActivity() {
         super.onResume()
         if (::webView.isInitialized) {
             updateWebNotificationPermissionState()
+            viewModel.resumeAutoRetryIfNeeded()
         }
+    }
+
+    override fun onStop() {
+        super.onStop()
+        // Avoid background polling; restart on resume if the error screen is still active.
+        viewModel.cancelAutoRetry()
     }
 
     /** Handles hermes://session/{session_id} deep links.

--- a/app/src/main/java/com/hermeswebui/android/ui/MainUiState.kt
+++ b/app/src/main/java/com/hermeswebui/android/ui/MainUiState.kt
@@ -7,6 +7,7 @@ data class MainUiState(
     val isLoading: Boolean = true,
     val hasLoadedContent: Boolean = false,
     val isOffline: Boolean = false,
+    val isReconnecting: Boolean = false,
     val errorMessage: String? = null,
     val isSettingsVisible: Boolean = false,
     val pendingShareBanner: String? = null,

--- a/app/src/main/java/com/hermeswebui/android/ui/MainViewModel.kt
+++ b/app/src/main/java/com/hermeswebui/android/ui/MainViewModel.kt
@@ -5,8 +5,13 @@ import androidx.lifecycle.viewModelScope
 import com.hermeswebui.android.data.HermesApiClient
 import com.hermeswebui.android.data.SettingsStore
 import com.hermeswebui.android.data.SharePayload
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -14,18 +19,24 @@ import kotlinx.coroutines.launch
 class MainViewModel(
     private val settingsRepository: SettingsStore,
     private val defaultUrl: String,
-    private val defaultDashboardUrl: String
+    private val defaultDashboardUrl: String,
+    private val serverReachabilityChecker: suspend (String) -> Boolean = HermesApiClient::isServerReachable
 ) : ViewModel() {
     private val settings = settingsRepository.getSettings(defaultUrl, defaultDashboardUrl)
 
     private val _uiState = MutableStateFlow(MainUiState(settings = settings))
     val uiState: StateFlow<MainUiState> = _uiState.asStateFlow()
 
-    private var sharedText: String? = null
-    private var sharedFileUris: List<String> = emptyList()
+    /** Emits a single Unit when the auto-retry loop detects the server is back.
+     *  The UI layer (MainActivity) should call webView.reload() on each emission. */
+    private val _autoReloadEvent = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val autoReloadEvent: SharedFlow<Unit> = _autoReloadEvent.asSharedFlow()
+
+    private var autoRetryJob: Job? = null
     private var currentLoadHasMainFrameError = false
 
     fun onPageStarted(url: String?) {
+        cancelAutoRetry()
         currentLoadHasMainFrameError = false
         _uiState.update {
             it.copy(
@@ -73,20 +84,53 @@ class MainViewModel(
                 isOffline = isOffline
             )
         }
-        // If the device appears online but the page failed, probe /api/status to
-        // distinguish "server is down" from a transient content/navigation error.
-        // /api/status is the public liveness endpoint on Hermes WebUI; no auth needed.
-        if (!isOffline) {
-            val serverUrl = _uiState.value.settings.serverUrl
-            if (serverUrl.isNotBlank()) {
-                viewModelScope.launch {
-                    if (!HermesApiClient.isServerReachable(serverUrl)) {
-                        _uiState.update { it.copy(isOffline = true) }
-                    }
+        startAutoRetry()
+    }
+
+    /** Starts the bounded auto-retry polling loop.
+     *
+     * Polls [serverReachabilityChecker] with exponential backoff starting at 1 s,
+     * capped at 10 s per interval, for up to 60 s total. On the first successful
+     * probe it emits [autoReloadEvent] so the UI can trigger a WebView reload.
+     * Sets [MainUiState.isReconnecting] while the loop is active.
+     */
+    private fun startAutoRetry() {
+        autoRetryJob?.cancel()
+        val serverUrl = _uiState.value.settings.serverUrl
+        if (serverUrl.isBlank()) return
+
+        autoRetryJob = viewModelScope.launch {
+            var intervalMs = 1_000L
+            val maxIntervalMs = 10_000L
+            val deadlineMs = System.currentTimeMillis() + 60_000L
+            _uiState.update { it.copy(isReconnecting = true) }
+
+            while (System.currentTimeMillis() < deadlineMs) {
+                delay(intervalMs)
+                if (serverReachabilityChecker(serverUrl)) {
+                    _uiState.update { it.copy(isReconnecting = false) }
+                    _autoReloadEvent.tryEmit(Unit)
+                    return@launch
                 }
+                // Server still unreachable — confirm offline state and back off.
+                _uiState.update { it.copy(isOffline = true) }
+                intervalMs = (intervalMs * 2).coerceAtMost(maxIntervalMs)
             }
+
+            // Timed out after ~60 s: give up, leave error screen, stop spinning.
+            _uiState.update { it.copy(isReconnecting = false) }
         }
     }
+
+    /** Cancels any active auto-retry loop and clears the reconnecting indicator. */
+    fun cancelAutoRetry() {
+        autoRetryJob?.cancel()
+        autoRetryJob = null
+        _uiState.update { it.copy(isReconnecting = false) }
+    }
+
+    private var sharedText: String? = null
+    private var sharedFileUris: List<String> = emptyList()
 
     fun consumeSharePayload(payload: SharePayload) {
         sharedText = payload.sharedText?.takeIf { it.isNotBlank() }
@@ -119,6 +163,7 @@ class MainViewModel(
     }
 
     fun saveAppUrls(serverUrl: String, dashboardUrl: String) {
+        cancelAutoRetry()
         settingsRepository.saveAppUrls(serverUrl, dashboardUrl)
         val refreshed = settingsRepository.getSettings(defaultUrl, defaultDashboardUrl)
         _uiState.update {
@@ -135,6 +180,7 @@ class MainViewModel(
     }
 
     fun resetSession() {
+        cancelAutoRetry()
         settingsRepository.clearWebSession()
         _uiState.update {
             it.copy(

--- a/app/src/main/java/com/hermeswebui/android/ui/MainViewModel.kt
+++ b/app/src/main/java/com/hermeswebui/android/ui/MainViewModel.kt
@@ -129,6 +129,17 @@ class MainViewModel(
         _uiState.update { it.copy(isReconnecting = false) }
     }
 
+    /**
+     * Restarts bounded auto-retry when returning to foreground and the app is
+     * still showing a load error.
+     */
+    fun resumeAutoRetryIfNeeded() {
+        val state = _uiState.value
+        if (state.errorMessage == null || state.isLoading) return
+        if (autoRetryJob?.isActive == true) return
+        startAutoRetry()
+    }
+
     private var sharedText: String? = null
     private var sharedFileUris: List<String> = emptyList()
 

--- a/app/src/main/java/com/hermeswebui/android/ui/web/WebShell.kt
+++ b/app/src/main/java/com/hermeswebui/android/ui/web/WebShell.kt
@@ -30,6 +30,7 @@ fun WebShell(
     isLoading: Boolean,
     hasLoadedContent: Boolean,
     isOffline: Boolean,
+    isReconnecting: Boolean,
     errorMessage: String?,
     onRefresh: () -> Unit,
     onRetry: () -> Unit,
@@ -78,10 +79,18 @@ fun WebShell(
                     style = MaterialTheme.typography.headlineSmall
                 )
                 Text(
-                    modifier = Modifier.padding(top = 8.dp, bottom = 16.dp),
+                    modifier = Modifier.padding(top = 8.dp, bottom = if (isReconnecting) 4.dp else 16.dp),
                     text = errorMessage,
                     style = MaterialTheme.typography.bodyMedium
                 )
+                if (isReconnecting) {
+                    Text(
+                        modifier = Modifier.padding(bottom = 16.dp),
+                        text = "Reconnecting\u2026",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.secondary
+                    )
+                }
                 Button(onClick = onRetry) {
                     Text("Retry")
                 }

--- a/app/src/test/java/com/hermeswebui/android/MainViewModelTest.kt
+++ b/app/src/test/java/com/hermeswebui/android/MainViewModelTest.kt
@@ -4,11 +4,35 @@ import com.google.common.truth.Truth.assertThat
 import com.hermeswebui.android.data.AppSettings
 import com.hermeswebui.android.data.SettingsStore
 import com.hermeswebui.android.ui.MainViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class MainViewModelTest {
     private val defaultServerUrl = "https://hermes.example.com"
     private val defaultDashboardUrl = ""
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
 
     @Test
     fun `visible commit marks loaded content`() {
@@ -162,6 +186,74 @@ class MainViewModelTest {
         val state = viewModel.uiState.value
         assertThat(state.currentUrl).isEqualTo(dashboardUrl)
         assertThat(store.lastLoadedUrl).isEqualTo(defaultServerUrl)
+    }
+
+    // --- Auto-retry tests ---
+
+    @Test
+    fun `auto-retry sets isReconnecting and auto-reload fires when server becomes reachable`() = runTest(testDispatcher) {
+        var probeCount = 0
+        val viewModel = MainViewModel(FakeSettingsStore(), defaultServerUrl, defaultDashboardUrl) { _ ->
+            probeCount++
+            probeCount >= 2 // fail first probe, succeed on second
+        }
+
+        val autoReloads = mutableListOf<Unit>()
+        backgroundScope.launch { viewModel.autoReloadEvent.collect { autoReloads += it } }
+
+        viewModel.onPageError("net::ERR_CONNECTION_REFUSED", isOffline = false)
+        runCurrent() // let the retry coroutine start and set isReconnecting
+
+        assertThat(viewModel.uiState.value.isReconnecting).isTrue()
+        assertThat(viewModel.uiState.value.errorMessage).isNotNull()
+
+        // Advance past first 1 s interval — probe fails, isOffline confirmed
+        advanceTimeBy(1_001L)
+        runCurrent()
+        assertThat(autoReloads).isEmpty()
+        assertThat(viewModel.uiState.value.isOffline).isTrue()
+        assertThat(viewModel.uiState.value.isReconnecting).isTrue()
+
+        // Advance past second 2 s interval — probe succeeds, auto-reload event fires
+        advanceTimeBy(2_001L)
+        runCurrent()
+        assertThat(autoReloads).hasSize(1)
+        assertThat(viewModel.uiState.value.isReconnecting).isFalse()
+    }
+
+    @Test
+    fun `cancelAutoRetry stops polling and clears isReconnecting`() = runTest(testDispatcher) {
+        var probeCount = 0
+        val viewModel = MainViewModel(FakeSettingsStore(), defaultServerUrl, defaultDashboardUrl) { _ ->
+            probeCount++
+            false // never succeed
+        }
+
+        viewModel.onPageError("net::ERR_CONNECTION_REFUSED", isOffline = false)
+        runCurrent()
+        assertThat(viewModel.uiState.value.isReconnecting).isTrue()
+
+        viewModel.cancelAutoRetry()
+        assertThat(viewModel.uiState.value.isReconnecting).isFalse()
+
+        // Advance well past first interval — no probes should fire after cancel
+        advanceTimeBy(5_000L)
+        runCurrent()
+        assertThat(probeCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `onPageStarted cancels auto-retry and clears error`() = runTest(testDispatcher) {
+        val viewModel = MainViewModel(FakeSettingsStore(), defaultServerUrl, defaultDashboardUrl) { _ -> false }
+
+        viewModel.onPageError("error", isOffline = false)
+        runCurrent()
+        assertThat(viewModel.uiState.value.isReconnecting).isTrue()
+
+        viewModel.onPageStarted(defaultServerUrl)
+        assertThat(viewModel.uiState.value.isReconnecting).isFalse()
+        assertThat(viewModel.uiState.value.errorMessage).isNull()
+        assertThat(viewModel.uiState.value.isLoading).isTrue()
     }
 
     private class FakeSettingsStore : SettingsStore {

--- a/app/src/test/java/com/hermeswebui/android/MainViewModelTest.kt
+++ b/app/src/test/java/com/hermeswebui/android/MainViewModelTest.kt
@@ -256,6 +256,47 @@ class MainViewModelTest {
         assertThat(viewModel.uiState.value.isLoading).isTrue()
     }
 
+    @Test
+    fun `resumeAutoRetryIfNeeded restarts polling after cancel when still in error state`() = runTest(testDispatcher) {
+        var probeCount = 0
+        val viewModel = MainViewModel(FakeSettingsStore(), defaultServerUrl, defaultDashboardUrl) { _ ->
+            probeCount++
+            false
+        }
+
+        viewModel.onPageError("error", isOffline = false)
+        runCurrent()
+        assertThat(viewModel.uiState.value.isReconnecting).isTrue()
+
+        viewModel.cancelAutoRetry()
+        assertThat(viewModel.uiState.value.isReconnecting).isFalse()
+
+        viewModel.resumeAutoRetryIfNeeded()
+        runCurrent()
+        assertThat(viewModel.uiState.value.isReconnecting).isTrue()
+
+        advanceTimeBy(1_001L)
+        runCurrent()
+        assertThat(probeCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `resumeAutoRetryIfNeeded does nothing without error state`() = runTest(testDispatcher) {
+        var probeCount = 0
+        val viewModel = MainViewModel(FakeSettingsStore(), defaultServerUrl, defaultDashboardUrl) { _ ->
+            probeCount++
+            false
+        }
+
+        viewModel.resumeAutoRetryIfNeeded()
+        runCurrent()
+
+        advanceTimeBy(2_000L)
+        runCurrent()
+        assertThat(probeCount).isEqualTo(0)
+        assertThat(viewModel.uiState.value.isReconnecting).isFalse()
+    }
+
     private class FakeSettingsStore : SettingsStore {
         private var settings = AppSettings(
             serverUrl = "https://hermes.example.com",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ materialComponents = "1.14.0"
 junit = "4.13.2"
 truth = "1.4.5"
 androidxTestExtJunit = "1.2.1"
+coroutinesTest = "1.10.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -30,6 +31,7 @@ androidx-security-crypto = { group = "androidx.security", name = "security-crypt
 google-material = { group = "com.google.android.material", name = "material", version.ref = "materialComponents" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExtJunit" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }


### PR DESCRIPTION
## What this changes
- adds bounded native auto-retry after WebView main-frame load errors
- probes /api/status on 1s -> 2s -> 4s -> 8s -> 10s capped backoff (max ~60s)
- auto-reloads WebView on first successful probe
- surfaces a Reconnecting... hint on the native error screen
- cancels retry loop on manual Retry/navigation/settings reset to avoid duplicate reload races
- pauses polling while app is backgrounded and resumes retry on foreground when still in error state
- adds coroutine-based MainViewModel tests for retry success, cancellation, and foreground resume behavior
## Why
This fixes the post-update window where users could get stuck on the native error screen if they refreshed while the server was still restarting.
## Verification
- ./gradlew test --no-daemon
- ./gradlew assembleDebug --no-daemon
Closes #9