### PR TITLE
REL-014: add richer GitHub release details body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,44 @@ jobs:
           ./gradlew test :app:stageGithubReleaseApk --no-daemon
           find build/release -maxdepth 1 -type f -name '*.apk' -print
 
+      - name: Build release notes body
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release_version.outputs.tag_name }}
+        run: |
+          apk_path="$(find build/release -maxdepth 1 -type f -name 'hermes-webui-v*-github.apk' | head -n 1)"
+          test -n "$apk_path" || { echo "No staged GitHub APK found"; exit 1; }
+          apk_name="$(basename "$apk_path")"
+          apk_sha256="$(sha256sum "$apk_path" | awk '{print $1}')"
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          generated_notes="$(gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+            -f tag_name="$RELEASE_TAG" \
+            -f target_commitish="$GITHUB_SHA" \
+            --jq '.body')"
+
+          cat > build/release/release-notes.md <<EOF
+          ## Release Details
+
+          - Version: \
+            `${{ steps.release_version.outputs.version_name }}`
+          - Tag: \
+            `$RELEASE_TAG`
+          - Commit: \
+            `$GITHUB_SHA`
+          - Artifact: \
+            `$apk_name`
+          - SHA-256: \
+            `$apk_sha256`
+          - Workflow run: \
+            $run_url
+
+          ---
+
+          $generated_notes
+          EOF
+
       - name: Upload signed GitHub APK artifact
         uses: actions/upload-artifact@v7
         with:
@@ -89,13 +127,16 @@ jobs:
           RELEASE_TAG: ${{ steps.release_version.outputs.tag_name }}
         run: |
           if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --target "$GITHUB_SHA"
+            gh release edit "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --target "$GITHUB_SHA" \
+              --notes-file build/release/release-notes.md
             gh release upload "$RELEASE_TAG" build/release/*.apk --repo "$GITHUB_REPOSITORY" --clobber
           else
             gh release create "$RELEASE_TAG" build/release/*.apk \
               --repo "$GITHUB_REPOSITORY" \
               --target "$GITHUB_SHA" \
               --title "Hermes WebUI Android $RELEASE_TAG" \
-              --generate-notes
+              --notes-file build/release/release-notes.md
           fi
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ The workflow in `.github/workflows/release.yml` can then:
 - upload it as a workflow artifact on manual runs
 - create or update a GitHub Release automatically from manual runs using the Gradle Android `versionName`
 - attach the APK to a GitHub Release automatically when you push a matching `v*` tag
+- include a release body with explicit build details (version/tag, commit SHA, APK filename, SHA-256, workflow run URL) plus generated GitHub notes
 - fail a tag release when the tag, such as `v0.1.8`, does not match the Android `versionName`
 - keep release notes scoped to app/runtime changes in that release (exclude workflow-only and docs-only updates)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -157,6 +157,7 @@ workflow changes should be made in Hermes WebUI instead.
 | REL-012 | 2026-06-23 | Release | Wired `.github/workflows/play-aab.yml` to upload the signed `hermes-webui-v<version>.aab` artifact to the Google Play internal testing track using the configured Play service-account secret |
 | REL-013 | 2026-06-23 | Release | Split GitHub APK builds into a separate `github` release build type with `applicationIdSuffix = ".github"` and `versionNameSuffix = "-github"` so sideloaded GitHub builds can install beside Google Play builds |
 | BUG-015 | 2026-06-23 | WebView | Fixed Issue 9: added bounded auto-retry loop on server error — polls `/api/status` with 1 s → 2 s → 4 s → 10 s cap backoff for up to 60 s, auto-reloads when server comes back, shows "Reconnecting…" on the error screen, cancels cleanly on manual Retry / new navigation / settings save |
+| REL-014 | 2026-06-23 | Release | Enhanced `.github/workflows/release.yml` GitHub Release notes: each release now includes explicit build metadata (version/tag, commit SHA, APK filename, SHA-256, workflow run URL) followed by generated GitHub notes, for both create and update paths |
 
 ---
 


### PR DESCRIPTION
## What this changes
- updates `.github/workflows/release.yml` to build a deterministic release-notes body before publishing
- includes explicit metadata in every GitHub Release body:
  - version + tag
  - commit SHA
  - APK filename
  - SHA-256 hash for integrity verification
  - workflow run URL
- appends GitHub-generated release notes after the metadata block
- applies this for both release create and release update paths (`gh release create` and `gh release edit`)
## Why
Release entries previously relied only on generated notes and did not always include build-level metadata users can quickly verify.
## Docs
- updated `README.md` release workflow section
- added roadmap entry `REL-014`
## Verification
- `./gradlew test --no-daemon`
