### PR TITLE
Fix #35: enable native text selection in conversation WebView

### DIFF
--- a/app/src/main/java/com/hermeswebui/android/MainActivity.kt
+++ b/app/src/main/java/com/hermeswebui/android/MainActivity.kt
@@ -1045,8 +1045,10 @@ class MainActivity : ComponentActivity() {
             settings.userAgentString = "${settings.userAgentString} Hermes-Android/${appVersionName()}"
             disableWebViewDarkening(settings)
             installHermesNotificationWebMessageBridge(this)
-            isLongClickable = false
-            setOnLongClickListener { true }
+            // Allow native long-press so Android's text selection handles appear in
+            // conversation messages (issue #35). Default WebView behavior already
+            // routes long-press on links to the system context menu.
+            isLongClickable = true
 
             CookieManager.getInstance().setAcceptCookie(true)
             CookieManager.getInstance().setAcceptThirdPartyCookies(this, false)


### PR DESCRIPTION
The WebView set isLongClickable=false and installed an OnLongClickListener that consumed every long-press (return true). This swallowed the gesture before Android's ActionMode could start, so text selection handles never appeared and users could not copy code blocks or messages.

The JS-injected long-press context menu that originally required swallowing the native gesture has since been removed, leaving these two lines as dead weight that only suppressed selection. Restore the default by enabling long-click and dropping the consuming listener; long-press on links still routes to the system context menu as before.