### PR TITLE
Suppress false-positive LAN permission toast on OEM Android 16

### DIFF
--- a/app/src/main/java/com/hermeswebui/android/MainActivity.kt
+++ b/app/src/main/java/com/hermeswebui/android/MainActivity.kt
@@ -238,7 +238,13 @@ class MainActivity : ComponentActivity() {
             if (granted) {
                 onGranted?.invoke()
             } else {
-                Toast.makeText(this, "Local network permission denied", Toast.LENGTH_SHORT).show()
+                // Only surface the denial toast when there is no best-effort fallback
+                // (i.e. this is the hard-fail WebView error-recovery path). Pre-load
+                // preflight denials on OEM builds that don't expose a real grant toggle
+                // should not produce a visible error because the load will still proceed.
+                if (onDenied == null) {
+                    Toast.makeText(this, "Local network permission denied", Toast.LENGTH_SHORT).show()
+                }
                 onDenied?.invoke()
             }
         }


### PR DESCRIPTION
## What changed

Suppresses the \Local network permission denied\ toast that fires on startup on OEM Android 16 builds where \ACCESS_LOCAL_NETWORK\ is auto-denied without a user-visible toggle.

The toast now only appears when the denial comes from the hard-fail error-recovery path (i.e. Android WebView already returned \ERR_LOCAL_NETWORK_PERMISSION_MISSING\). Best-effort preflight denials on startup, save, and server-switch flows proceed silently.

## Testing

- \./gradlew test --no-daemon\ passed.

Related #49