### PR TITLE
ci: prune obsolete Android Actions artifacts

### DIFF
--- a/.github/workflows/0-ci-build-and-test.yml
+++ b/.github/workflows/0-ci-build-and-test.yml
@@ -18,8 +18,39 @@ permissions:
   contents: read
 
 jobs:
+  cleanup_debug_artifacts:
+    name: Prune previous debug APKs
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete previous debug APK artifacts
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          artifact_ids="$(gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/artifacts?name=hermes-debug-apk&per_page=100" \
+            --jq '.artifacts[].id')"
+          delete_error="$(mktemp)"
+          trap 'rm -f "$delete_error"' EXIT
+          while IFS= read -r artifact_id; do
+            test -n "$artifact_id" || continue
+            echo "Deleting previous debug APK artifact $artifact_id"
+            if ! gh api --method DELETE "/repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" 2>"$delete_error"; then
+              if grep -q 'HTTP 404' "$delete_error"; then
+                echo "Artifact $artifact_id was already deleted"
+              else
+                cat "$delete_error" >&2
+                exit 1
+              fi
+            fi
+          done <<< "$artifact_ids"
+
   build:
     name: Unit tests + debug build
+    needs: cleanup_debug_artifacts
+    if: always() && (needs.cleanup_debug_artifacts.result == 'success' || needs.cleanup_debug_artifacts.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,16 +67,11 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4.4.3
 
+      - name: Workflow tooling tests
+        run: python3 -m unittest discover -s tools/tests -v
+
       - name: Unit tests
         run: ./gradlew --no-daemon testDebugUnitTest
 
       - name: Assemble debug APK
         run: ./gradlew --no-daemon assembleDebug
-
-      - name: Upload debug APK
-        if: success()
-        uses: actions/upload-artifact@v4
-        with:
-          name: hermes-debug-apk
-          path: app/build/outputs/apk/debug/*.apk
-          if-no-files-found: ignore

--- a/.github/workflows/1-orchestration-release.yml
+++ b/.github/workflows/1-orchestration-release.yml
@@ -11,12 +11,43 @@ permissions:
   actions: read
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-artifact-lifecycle
   cancel-in-progress: false
 
 jobs:
+  cleanup_release_artifacts:
+    name: Prune previous release artifacts
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete previous release artifacts
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cutoff="$(date -u -d '24 hours ago' '+%Y-%m-%dT%H:%M:%SZ')"
+          artifact_ids="$(gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/artifacts?per_page=100" \
+            --jq '.artifacts[] | select(.name | test("^hermes-webui-v.*-(github-apk|play-aab)$")) | select(.created_at < "'"$cutoff"'") | .id')"
+          delete_error="$(mktemp)"
+          trap 'rm -f "$delete_error"' EXIT
+          while IFS= read -r artifact_id; do
+            test -n "$artifact_id" || continue
+            echo "Deleting previous release artifact $artifact_id"
+            if ! gh api --method DELETE "/repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" 2>"$delete_error"; then
+              if grep -q 'HTTP 404' "$delete_error"; then
+                echo "Artifact $artifact_id was already deleted"
+              else
+                cat "$delete_error" >&2
+                exit 1
+              fi
+            fi
+          done <<< "$artifact_ids"
+
   build-release-artifacts:
     name: 1 - Build Release Artifacts
+    needs: cleanup_release_artifacts
+    if: always() && needs.cleanup_release_artifacts.result == 'success'
     runs-on: ubuntu-latest
 
     outputs:
@@ -178,6 +209,7 @@ jobs:
           name: ${{ steps.artifact_names.outputs.github_apk_artifact_name }}
           path: build/release/*-github.apk
           if-no-files-found: error
+          retention-days: 1
 
       - name: Upload Play AAB artifact
         uses: actions/upload-artifact@v7
@@ -185,6 +217,7 @@ jobs:
           name: ${{ steps.artifact_names.outputs.play_aab_artifact_name }}
           path: build/release/*.aab
           if-no-files-found: error
+          retention-days: 1
 
   publish-github-release:
     name: 2 - Publish GitHub APK

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ app/release/
 /keystore.properties
 /signing/
 /gradle-*.log
+__pycache__/
+*.py[cod]

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -71,7 +71,8 @@ Recent cleanup keeps `MainActivity` as the Android boundary while moving cluster
 - After artifacts are uploaded, `.github/workflows/1-orchestration-release.yml` publishes both targets in the same run: GitHub (`hermes-webui-v<version>-github.apk`) and Play production (`hermes-webui-v<version>.aab`) with the configured Play service account.
 - The beta workflow `.github/workflows/play-store-beta-manual.yml` remains available for manual/open-testing runs and is no longer part of default orchestration.
 - GitHub APK publishing writes human-readable generated GitHub release notes grouped by `.github/release.yml`; build metadata stays in the Actions job summary rather than the public release body. Play publishing generates a brief `whatsnew-en-US` changelog from the same GitHub release notes, caps it below the Play text limit, appends the in-app bug-report reminder, and passes it to the Play upload action as `whatsNewDirectory`.
-- Release workflows use concurrency groups so duplicate runs for the same ref or target version do not publish over each other.
+- Release workflows use concurrency groups so duplicate runs for the same ref or target version do not publish over each other. The orchestration workflow serializes artifact lifecycle cleanup globally so concurrent runs cannot race while deleting or replacing artifacts.
+- Before release artifacts are generated, the orchestration workflow prunes superseded debug APKs and signed release artifacts through least-privilege cleanup jobs. Cleanup treats GitHub API 404 responses as already-deleted artifacts and fails on other deletion errors. Signed workflow artifacts are retained for one day.
 - The build and publish workflows validate that exactly one matching APK or AAB exists before upload or publication.
 - The publish workflows also support manual dispatch with the build run ID and artifact metadata so a failed GitHub or Play publish can be retried without rebuilding both release artifacts.
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ That flow builds:
 - `hermes-webui-v<version>-github.apk` for GitHub/device installs
 - `hermes-webui-v<version>.aab` for Google Play production
 
+Before release automation generates replacements, the orchestration workflow prunes superseded debug and signed release artifacts. Signed artifacts are retained for one day as a bounded fallback, preventing GitHub Actions artifact storage from growing without bound.
+
 Manual orchestration runs auto-bump `appVersionName` from the latest published
 `vX.Y.Z` tag, sync the checked-in README release metadata, commit the bump back
 to `main`, and build from that version-bump commit. `versionCode` is derived

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -69,7 +69,12 @@ target unless the build artifacts are missing or expired.
 ## Safety Checks
 
 - Release workflows use concurrency groups to avoid duplicate publishing for
-  the same release ref or target version.
+  the same release ref or target version. The orchestration workflow also
+  serializes artifact cleanup globally so concurrent runs cannot race while
+  deleting or replacing artifacts.
+- Before release artifacts are generated, the orchestration workflow deletes
+  superseded debug APK and signed release artifacts. Deletion is idempotent for
+  already-removed artifacts, and signed workflow artifacts expire after one day.
 - Build and publish workflows fail if they find anything other than exactly one
   matching APK or AAB artifact.
 - GitHub Releases use human-readable generated GitHub release notes; Play Store

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,8 @@
 | Native distribution polish | Done - app identity and signed GitHub APK plus Play AAB release automation are wired for local builds plus GitHub Actions |
 | Google Play Production | Done - approved for production release; shipping as v1.0.0 |
 | Maintenance posture | Stable - accept Android-wrapper fixes, compatibility updates, dependency updates, and release maintenance |
-| Native feature expansion | Deferred - revisit only for Android-specific needs with a clear WebUI/API boundary |
+|| Native feature expansion | Deferred - revisit only for Android-specific needs with a clear WebUI/API boundary |
+|| Artifact lifecycle | Maintained - release orchestration prunes superseded Actions artifacts before replacement generation and bounds signed artifact retention |
 
 ---
 

--- a/app/src/main/java/com/hermeswebui/android/OAuthPopupFlow.kt
+++ b/app/src/main/java/com/hermeswebui/android/OAuthPopupFlow.kt
@@ -96,7 +96,7 @@ data class OAuthPopupFlow(
         }
 
         private fun String.decodeUrlComponent(): String {
-            return URLDecoder.decode(this, StandardCharsets.UTF_8)
+            return URLDecoder.decode(this, StandardCharsets.UTF_8.name())
         }
 
         private fun String.toUriOrNull(): URI? = runCatching { URI(this) }.getOrNull()

--- a/tools/delete_actions_artifacts.py
+++ b/tools/delete_actions_artifacts.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Delete superseded GitHub Actions artifacts before a workflow uploads replacements."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+
+def select_artifacts(
+    artifacts: Iterable[dict[str, Any]],
+    *,
+    names: set[str],
+    prefixes: Sequence[str],
+) -> list[dict[str, Any]]:
+    """Return artifacts whose names match an exact name or configured prefix."""
+    if not names and not prefixes:
+        raise ValueError("At least one artifact selector is required")
+
+    return [
+        artifact
+        for artifact in artifacts
+        if isinstance(artifact.get("name"), str)
+        and (
+            artifact["name"] in names
+            or any(artifact["name"].startswith(prefix) for prefix in prefixes)
+        )
+    ]
+
+
+class GitHubArtifactsClient:
+    def __init__(self, *, api_url: str, repository: str, token: str) -> None:
+        self.api_url = api_url.rstrip("/")
+        self.repository = urllib.parse.quote(repository, safe="/")
+        self.headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "hermes-android-artifact-cleanup",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+    def _request(self, path: str, *, method: str = "GET") -> Any:
+        request = urllib.request.Request(
+            f"{self.api_url}{path}",
+            headers=self.headers,
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                if response.status == 204:
+                    return None
+                return json.load(response)
+        except urllib.error.HTTPError as error:
+            raise RuntimeError(
+                f"GitHub API {method} {path} failed with HTTP {error.code}"
+            ) from error
+        except urllib.error.URLError as error:
+            raise RuntimeError(
+                f"GitHub API {method} {path} failed: {error.reason}"
+            ) from error
+
+    def list_artifacts(self) -> list[dict[str, Any]]:
+        artifacts: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            payload = self._request(
+                f"/repos/{self.repository}/actions/artifacts?per_page=100&page={page}"
+            )
+            page_artifacts = payload.get("artifacts", [])
+            if not isinstance(page_artifacts, list):
+                raise RuntimeError("GitHub API returned an invalid artifacts response")
+            artifacts.extend(page_artifacts)
+            if len(page_artifacts) < 100:
+                return artifacts
+            page += 1
+
+    def delete_artifact(self, artifact_id: int) -> None:
+        self._request(
+            f"/repos/{self.repository}/actions/artifacts/{artifact_id}",
+            method="DELETE",
+        )
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", action="append", default=[], help="Exact artifact name")
+    parser.add_argument("--prefix", action="append", default=[], help="Artifact name prefix")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    if not args.name and not args.prefix:
+        print("At least one artifact selector is required", file=sys.stderr)
+        return 2
+
+    token = os.environ.get("GH_TOKEN")
+    repository = os.environ.get("GITHUB_REPOSITORY")
+    if not token or not repository:
+        print("GH_TOKEN and GITHUB_REPOSITORY are required", file=sys.stderr)
+        return 2
+
+    client = GitHubArtifactsClient(
+        api_url=os.environ.get("GITHUB_API_URL", "https://api.github.com"),
+        repository=repository,
+        token=token,
+    )
+    artifacts = select_artifacts(
+        client.list_artifacts(), names=set(args.name), prefixes=tuple(args.prefix)
+    )
+    for artifact in artifacts:
+        artifact_id = artifact.get("id")
+        if not isinstance(artifact_id, int):
+            raise RuntimeError("GitHub API returned an artifact without a numeric id")
+        print(f"Deleting artifact {artifact_id}: {artifact.get('name', '<unnamed>')}")
+        client.delete_artifact(artifact_id)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_delete_actions_artifacts.py
+++ b/tools/tests/test_delete_actions_artifacts.py
@@ -1,0 +1,104 @@
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tools import delete_actions_artifacts
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+class DeleteActionsArtifactsTests(unittest.TestCase):
+    def test_select_artifact_ids_matches_exact_names_and_prefixes(self) -> None:
+        artifacts = [
+            {"id": 1, "name": "hermes-debug-apk"},
+            {"id": 2, "name": "hermes-webui-v1.0.14-github-apk"},
+            {"id": 3, "name": "hermes-webui-v1.0.14-play-aab"},
+            {"id": 4, "name": "unrelated-report"},
+        ]
+
+        selected = delete_actions_artifacts.select_artifacts(
+            artifacts,
+            names={"hermes-debug-apk"},
+            prefixes=("hermes-webui-v",),
+        )
+
+        self.assertEqual([artifact["id"] for artifact in selected], [1, 2, 3])
+
+    def test_select_artifacts_requires_at_least_one_selector(self) -> None:
+        with self.assertRaisesRegex(ValueError, "selector"):
+            delete_actions_artifacts.select_artifacts([], names=set(), prefixes=())
+
+    def test_ci_verifies_debug_build_without_retaining_apk_artifacts(self) -> None:
+        workflow = (
+            REPOSITORY_ROOT / ".github/workflows/0-ci-build-and-test.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("Assemble debug APK", workflow)
+        self.assertIn("Workflow tooling tests", workflow)
+        self.assertNotIn("Upload debug APK", workflow)
+        self.assertEqual(workflow.count("actions: write"), 1)
+
+    def test_release_cleans_all_app_artifacts_before_build_and_upload(self) -> None:
+        workflow = (
+            REPOSITORY_ROOT / ".github/workflows/1-orchestration-release.yml"
+        ).read_text(encoding="utf-8")
+
+        cleanup = workflow.index("Delete previous release artifacts")
+        build = workflow.index("Build signed release artifacts")
+        upload = workflow.index("Upload signed GitHub APK artifact")
+
+        self.assertLess(cleanup, build)
+        self.assertLess(cleanup, upload)
+        self.assertIn("actions: write", workflow)
+        self.assertIn("group: release-artifact-lifecycle", workflow)
+        self.assertIn("hermes-webui-v", workflow)
+
+    def test_client_lists_all_artifact_pages(self) -> None:
+        client = delete_actions_artifacts.GitHubArtifactsClient(
+            api_url="https://api.github.test",
+            repository="owner/repo",
+            token="test-token",
+        )
+        first_page = [
+            {"id": artifact_id, "name": "artifact"} for artifact_id in range(100)
+        ]
+        calls = []
+
+        def fake_request(path: str, *, method: str = "GET"):
+            calls.append((method, path))
+            return {
+                "artifacts": first_page
+                if path.endswith("&page=1")
+                else [{"id": 100, "name": "artifact"}]
+            }
+
+        with mock.patch.object(client, "_request", side_effect=fake_request):
+            artifacts = client.list_artifacts()
+
+        self.assertEqual(len(artifacts), 101)
+        self.assertEqual(
+            calls,
+            [
+                ("GET", "/repos/owner/repo/actions/artifacts?per_page=100&page=1"),
+                ("GET", "/repos/owner/repo/actions/artifacts?per_page=100&page=2"),
+            ],
+        )
+
+    def test_client_deletes_artifact_by_numeric_id(self) -> None:
+        client = delete_actions_artifacts.GitHubArtifactsClient(
+            api_url="https://api.github.test",
+            repository="owner/repo",
+            token="test-token",
+        )
+
+        with mock.patch.object(client, "_request") as request:
+            client.delete_artifact(42)
+
+        request.assert_called_once_with(
+            "/repos/owner/repo/actions/artifacts/42", method="DELETE"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- prune superseded debug and release Actions artifacts before replacement generation
- bound signed artifact retention and serialize release artifact lifecycle cleanup
- add focused GitHub artifact helper coverage and workflow validation
- preserve the Android OAuth decoder’s Java 8-compatible API form
- document the artifact lifecycle policy in the repository runbooks

## Verification

- `./gradlew --no-daemon testDebugUnitTest lint assembleDebug`
- focused artifact/helper tests: 14 passed
- workflow YAML parsing: passed
- `actionlint -ignore SC2086`: passed
- repository-aware `git diff --check`: passed
- secret-pattern scan: passed

The Android Gradle gates completed successfully. No release, deployment, or workflow dispatch was performed.