### PR TITLE
Improve Android SSE session-stream diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ If a change belongs to Hermes everywhere, it belongs in WebUI first.
 - Share-to-app intake for text and files
 - Android-backed browser notifications for Hermes WebUI alerts
 - Optional ongoing background activity notification for trusted Hermes sessions
+- Persistent authenticated session-stream monitoring (`/api/session/stream`) for background activity updates, with reconnect polling fallback when live streaming is unavailable
 - Optional debug-log capture with persistent foreground notification and one-tap stop action
 - Channel-aware app updates: Play uses in-app update flow, GitHub APK builds download and hand off to installer in-app
 - GitHub APK updates surface a stateful in-app action flow (`Check` -> `Download` -> `Install`) and still show an install-ready notification when Hermes is backgrounded

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -126,6 +126,7 @@ sketches are captured inline below.
 
 | ID | Date | Area | Summary |
 |---|---|---|---|
+| SSE-001 | 2026-08-09 | Background continuity | Clarified the native SSE settings and notification status: Android keeps its persistent authenticated `/api/session/stream` preference when optional gateway extras are unavailable, presents that distinction clearly, and logs the safe active transport state for diagnostics. |
 | A-001 | 2026-06-19 | Build | Fixed Java/Gradle setup and verified `test` plus `assembleDebug` |
 | A-002 | 2026-06-19 | Security | Added URL policy validation and tests |
 | A-003 | 2026-06-19 | Tooling | Aligned AGP/Gradle to avoid Gradle 10 deprecation pressure |

--- a/app/src/main/java/com/hermeswebui/android/MainActivity.kt
+++ b/app/src/main/java/com/hermeswebui/android/MainActivity.kt
@@ -1302,16 +1302,16 @@ class MainActivity : ComponentActivity() {
                     ).show()
                 }
                 HermesApiClient.SseCapability.FEATURE_DISABLED -> {
-                    if (disableIfUnavailable) {
-                        viewModel.setSseTransportEnabled(false)
+                    if (enableIfAvailable) {
+                        viewModel.setSseTransportEnabled(true)
                     }
                     viewModel.setSseSupportStatus(
-                        "🚫  SSE not supported on this server right now. Gateway/session SSE is off and the reconnect stream was not detected." +
-                            if (disableIfUnavailable) " SSE transport was turned off." else ""
+                        "Info: Gateway SSE extras are unavailable. Android will still try the authenticated " +
+                            "/api/session/stream for the active session; the lightweight reconnect probe was not detected."
                     )
                     Toast.makeText(
                         this@MainActivity,
-                        "Gateway/session SSE not enabled on this server — see settings for how to turn it on.",
+                        "Gateway SSE extras unavailable; session streaming remains enabled.",
                         Toast.LENGTH_LONG
                     ).show()
                 }

--- a/app/src/main/java/com/hermeswebui/android/background/HermesReconnectService.kt
+++ b/app/src/main/java/com/hermeswebui/android/background/HermesReconnectService.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
@@ -74,10 +75,15 @@ class HermesReconnectService : Service() {
         activeIsReconnecting = isReconnecting
         activeShowFullTextOnLockScreen = showFullTextOnLockScreen
 
+        Log.i(
+            TAG,
+            "Background session monitor started: reconnecting=$isReconnecting, sessionStreamEnabled=$sseTransportEnabled, hasSession=${!sessionId.isNullOrBlank()}"
+        )
+
         val notification = buildNotification(
             pollIntervalSeconds = pollIntervalSeconds,
             contentText = currentNotificationBody.ifBlank {
-                defaultNotificationBody(pollIntervalSeconds, isReconnecting)
+                defaultNotificationBody(pollIntervalSeconds, isReconnecting, sseTransportEnabled)
             },
             targetUrl = currentNotificationTargetUrl ?: sessionTargetUrl,
             showFullTextOnLockScreen = showFullTextOnLockScreen,
@@ -265,9 +271,20 @@ class HermesReconnectService : Service() {
         }
     }
 
-    private fun defaultNotificationBody(pollIntervalSeconds: Int, isReconnecting: Boolean): String {
+    private fun defaultNotificationBody(
+        pollIntervalSeconds: Int,
+        isReconnecting: Boolean,
+        sseTransportEnabled: Boolean
+    ): String {
         if (!isReconnecting) {
-            return getString(R.string.reconnect_notification_body_activity)
+            return if (sseTransportEnabled) {
+                getString(R.string.reconnect_notification_body_session_stream)
+            } else {
+                getString(R.string.reconnect_notification_body_activity)
+            }
+        }
+        if (sseTransportEnabled) {
+            return getString(R.string.reconnect_notification_body_session_stream_reconnecting)
         }
         val normalizedInterval = pollIntervalSeconds.coerceAtLeast(1)
         return resources.getQuantityString(
@@ -585,6 +602,7 @@ class HermesReconnectService : Service() {
         private const val MAX_RESPONDED_APPROVAL_HISTORY = 64
         private const val ACTION_OPEN_NOTIFICATION_URL = "com.hermeswebui.android.OPEN_NOTIFICATION_URL"
         private const val EXTRA_NOTIFICATION_URL = "com.hermeswebui.android.extra.NOTIFICATION_URL"
+        private const val TAG = "HermesReconnectService"
 
         fun start(
             context: Context,

--- a/app/src/main/java/com/hermeswebui/android/data/HermesApiClient.kt
+++ b/app/src/main/java/com/hermeswebui/android/data/HermesApiClient.kt
@@ -88,20 +88,21 @@ object HermesApiClient {
      * regardless of this flag. This capability enum classifies the probe response, not whether
      * session streaming itself is functional.
      */
-    enum class SseCapability {
+    enum class SseCapability(val keepsSessionTransportEnabled: Boolean) {
         /** The WebUI gateway/session SSE probe reports the feature enabled and healthy. */
-        SESSION_SSE_ENABLED,
+        SESSION_SSE_ENABLED(true),
         /** The lightweight reconnect SSE stream is available, even if gateway/session SSE is not. */
-        RECONNECT_STREAM_AVAILABLE,
+        RECONNECT_STREAM_AVAILABLE(true),
         /**
          * The probe reported the gateway/session SSE feature disabled on this server.
          * This is the common "agent sessions not enabled" case and should be
-         * presented with a clear server-settings message rather than a generic error.
-         * Note: `/api/session/stream` may still be functional despite this probe result.
+         * presented as unavailable gateway extras rather than a generic transport failure.
+         * The persistent `/api/session/stream` endpoint may still be functional, so preserve the
+         * user's session-stream transport preference and let its authenticated connection decide.
          */
-        FEATURE_DISABLED,
+        FEATURE_DISABLED(true),
         /** No SSE capability detected (network error or unexpected server response). */
-        NONE
+        NONE(false)
     }
 
     /** The prompt text a user can paste into Hermes chat to ask it to enable session SSE. */

--- a/app/src/main/java/com/hermeswebui/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/hermeswebui/android/ui/settings/SettingsScreen.kt
@@ -828,7 +828,7 @@ fun SettingsScreen(
                                 },
                                 supportingContent = {
                                     Text(
-                                        text = "Beta: uses Hermes SSE endpoints for reconnect detection and falls back to polling if the server does not expose them.",
+                                        text = "Uses the persistent session stream for background activity updates, with reconnect polling as a fallback.",
                                         color = onSurfaceVar,
                                         style = MaterialTheme.typography.bodySmall
                                     )
@@ -851,7 +851,7 @@ fun SettingsScreen(
                                 }
                             )
                             Text(
-                                text = "When you turn SSE transport on, Android checks support automatically. If support is unavailable, the toggle turns back off. Use 'Check SSE support now' for a manual re-check.",
+                                text = "Android uses /api/session/stream for the active authenticated session, the same persistent stream used by Hermes WebUI. The optional gateway check reports approval and notification extras; it does not disable session streaming by itself.",
                                 color = onSurfaceVar.copy(alpha = 0.72f),
                                 style = MaterialTheme.typography.labelSmall
                             )
@@ -873,11 +873,10 @@ fun SettingsScreen(
                                 }
                             }
                             if (!sseSupportStatus.isNullOrBlank()) {
-                                val isFeatureDisabled = sseSupportStatus.startsWith("🚫")
                                 val statusColor = when {
                                     sseSupportStatus.startsWith("✅") -> Color(0xFF4CAF50)
+                                    sseSupportStatus.startsWith("Info:") -> onSurfaceVar.copy(alpha = 0.9f)
                                     sseSupportStatus.startsWith("❔") -> onSurfaceVar.copy(alpha = 0.82f)
-                                    isFeatureDisabled -> MaterialTheme.colorScheme.error
                                     sseSupportStatus.startsWith("❌") -> MaterialTheme.colorScheme.error
                                     else -> onSurfaceVar.copy(alpha = 0.72f)
                                 }
@@ -886,27 +885,6 @@ fun SettingsScreen(
                                     color = statusColor,
                                     style = MaterialTheme.typography.labelSmall
                                 )
-                                if (isFeatureDisabled) {
-                                    Spacer(modifier = Modifier.height(4.dp))
-                                    OutlinedButton(
-                                        onClick = onCopySsePrompt,
-                                        modifier = Modifier.fillMaxWidth(),
-                                        border = androidx.compose.foundation.BorderStroke(
-                                            1.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.6f)
-                                        )
-                                    ) {
-                                        Text(
-                                            "📋  Copy enable-SSE prompt for Hermes",
-                                            color = MaterialTheme.colorScheme.error,
-                                            style = MaterialTheme.typography.bodySmall
-                                        )
-                                    }
-                                    Text(
-                                        text = "Paste this into the Hermes chat to ask it to set the flag and restart.",
-                                        color = onSurfaceVar.copy(alpha = 0.65f),
-                                        style = MaterialTheme.typography.labelSmall
-                                    )
-                                }
                             }
                         }
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,8 @@
     <string name="action_edit_server_url">Edit server URL</string>
     <string name="reconnect_notification_title">Hermes activity is running in the background</string>
     <string name="reconnect_notification_body_activity">Watching the current Hermes session for safe activity updates.</string>
+    <string name="reconnect_notification_body_session_stream">Live session updates are active in the background.</string>
+    <string name="reconnect_notification_body_session_stream_reconnecting">Using live session updates while Hermes reconnects.</string>
     <string name="reconnect_notification_body_public_activity">Hermes is working in the background.</string>
     <string name="reconnect_notification_body_public_reconnecting">Hermes is trying to reconnect in the background.</string>
     <string name="approval_action_deny">Deny</string>

--- a/app/src/test/java/com/hermeswebui/android/HermesApiClientSseCapabilityTest.kt
+++ b/app/src/test/java/com/hermeswebui/android/HermesApiClientSseCapabilityTest.kt
@@ -59,6 +59,7 @@ class HermesApiClientSseCapabilityTest {
         )
 
         assertThat(result).isEqualTo(HermesApiClient.SseCapability.FEATURE_DISABLED)
+    assertThat(result.keepsSessionTransportEnabled).isTrue()
     }
 
     @Test
@@ -87,5 +88,6 @@ class HermesApiClientSseCapabilityTest {
         )
 
         assertThat(result).isEqualTo(HermesApiClient.SseCapability.NONE)
+    assertThat(result.keepsSessionTransportEnabled).isFalse()
     }
 }


### PR DESCRIPTION
## What changed

Clarifies the Android background SSE experience and keeps persistent session updates enabled when the optional gateway SSE contract is unavailable.

- Keeps the user's session-stream transport preference when the gateway probe reports disabled.
- Explains in native Settings that `/api/session/stream` is the persistent authenticated transport used by both Android and Hermes WebUI.
- Shows live session-stream activity in the background notification and records the safe active transport state in logcat.
- Documents the behavior and adds regression coverage for the capability decision.

## Testing

- `./gradlew.bat testDebugUnitTest --tests com.hermeswebui.android.HermesApiClientSseCapabilityTest --no-daemon`
- `./gradlew.bat testDebugUnitTest --no-daemon`
- `./gradlew.bat assembleDebug --no-daemon`

Closes #58