### PR TITLE
Fix OAuth scheme leniency port equivalence

### DIFF
--- a/.artifacts/a57c1120-2762-4456-b313-688e5a086839/scratch/pr_body.md
+++ b/.artifacts/a57c1120-2762-4456-b313-688e5a086839/scratch/pr_body.md
@@ -1,0 +1,15 @@
+## What changed
+Fixed a critical issue where OAuth login flows (like Nous with GitHub) would hang on the "Signing in" banner. 
+
+- **Interactive OAuth in Main WebView**: Intercepts `window.open` requests that start an OAuth flow and loads them in the primary visible WebView. This allows users to see and interact with login forms (credentials, MFA) that were previously trapped in hidden background popups.
+- **Public IP Support**: Relaxed origin matching to allow `http` and `https` scheme mismatches for identical hosts/ports. This is common in public IP or local network setups where the app and OIDC provider use different protocols.
+- **Broader Detection**: Updated `OAuthPopupFlow` to recognize more login path markers (`/auth`, `/login`, `/sso`) and added a fallback that identifies flows based on required parameters (`response_type=code`, `client_id`, `redirect_uri`).
+- **Mixed Content Compatibility**: Enabled `MIXED_CONTENT_COMPATIBILITY_MODE` to support transitions between secure and insecure contexts during login on non-standard networks.
+- **API 26 Compatibility**: Fixed a potential crash on older devices by using a more compatible `URLDecoder` overload.
+
+## Testing
+- Verified with unit tests in `OAuthPopupFlowTest.kt` covering new detection markers and parameter-based identification.
+- Verified successful `assembleDebug` build.
+- Verified that scheme leniency correctly identifies IP-based origins across protocols.
+
+Fixes #66

--- a/app/src/main/java/com/hermeswebui/android/MainActivity.kt
+++ b/app/src/main/java/com/hermeswebui/android/MainActivity.kt
@@ -45,7 +45,6 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
 import androidx.activity.ComponentActivity
-import androidx.activity.result.IntentSenderRequest
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts

--- a/app/src/main/java/com/hermeswebui/android/core/security/UrlPolicy.kt
+++ b/app/src/main/java/com/hermeswebui/android/core/security/UrlPolicy.kt
@@ -61,10 +61,18 @@ object UrlOrigins {
         val baseHost = base.normalizedHost() ?: return false
 
         val schemesMatch = ignoreScheme || targetScheme == baseScheme
+        val targetPort = target.effectivePort()
+        val basePort = base.effectivePort()
+
+        // When ignoring scheme, we also allow the standard web ports (80/443) to be equivalent.
+        val portsMatch = targetPort == basePort || (ignoreScheme && isStandardWebPort(targetPort) && isStandardWebPort(basePort))
+
         return schemesMatch &&
             targetHost == baseHost &&
-            target.effectivePort() == base.effectivePort()
+            portsMatch
     }
+
+    private fun isStandardWebPort(port: Int): Boolean = port == 80 || port == 443
 
     fun documentStartOriginRule(url: String): String? {
         val uri = url.toUriOrNull() ?: return null


### PR DESCRIPTION
This PR fixes a test failure in the previous OAuth interactive login change. It allows standard web ports (80/443) to be equivalent when scheme leniency is enabled, which is necessary for IP-based logins bridging HTTP and HTTPS.