### PR TITLE
Fix mTLS client-certificate support for Cloudflare Tunnel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,15 @@ When a user references GitHub issues (e.g., by URL or issue number), agents shou
 - If you must use inline `--body`, use a true PowerShell multiline here-string and verify output immediately.
 - Consider markdown rendering broken until verified in a non-JSON view (`gh pr view`, `gh issue view`, or GitHub web UI) after each update.
 
+### GitHub issue + PR workflow
+
+- For issue work, create or reuse a branch named after the issue (for example `issue-73`) before publishing any code.
+- Push the branch to GitHub with `git push --set-upstream origin <branch>` once the work is ready for review.
+- Create the PR with `gh pr create --title "<user-facing release note>" --body-file <path-to-markdown> --base main --head <branch>`; do not hand-write a long inline body in `--body`.
+- Attach the PR to the issue in the PR body by including a closing keyword such as `Fixes #123` or `Closes #123`; use `Related #123` when the PR contributes without fully resolving the issue.
+- If an issue needs a follow-up comment, post the same markdown content to the issue with a file-based body, such as `gh api repos/<owner>/<repo>/issues/<issue-number>/comments --input <path-to-markdown>`.
+- Always verify the rendered result with `gh pr view` or `gh issue view` after posting, and fix any markdown formatting regression immediately.
+
 ### PR and release-note quality
 
 - Write PR titles as user-facing release-note entries when the change may ship

--- a/app/src/main/java/com/hermeswebui/android/MainActivity.kt
+++ b/app/src/main/java/com/hermeswebui/android/MainActivity.kt
@@ -27,6 +27,7 @@ import android.os.SystemClock
 import android.provider.Settings
 import android.view.MotionEvent
 import android.view.WindowManager
+import android.webkit.ClientCertRequest
 import android.webkit.CookieManager
 import android.webkit.DownloadListener
 import android.webkit.PermissionRequest
@@ -103,6 +104,7 @@ import com.hermeswebui.android.data.HermesApiClient
 import com.hermeswebui.android.data.ServerProfile
 import com.hermeswebui.android.data.SettingsRepository
 import com.hermeswebui.android.notification.HermesNotificationBridgeCoordinator
+import com.hermeswebui.android.security.ClientCertificateRequestSupport
 import com.hermeswebui.android.notification.HermesNotificationPresenter
 import com.hermeswebui.android.domain.ServerUrlValidator
 import com.hermeswebui.android.server.HermesServerProfileCoordinator
@@ -679,6 +681,8 @@ class MainActivity : ComponentActivity() {
                     appUpdateDownloadUrl = uiState.appUpdateDownloadUrl,
                     appUpdateInstallReady = uiState.appUpdateInstallReady,
                     appUpdateReleaseNotes = uiState.appUpdateReleaseNotes,
+                    clientCertificateUri = uiState.clientCertificateUri,
+                    clientCertificatePassword = uiState.clientCertificatePassword,
                     serverValidation = uiState.serverValidation,
                     appVersionLabel = "Version ${appVersionName()}",
                     serverProfiles = serverProfiles,
@@ -736,6 +740,12 @@ class MainActivity : ComponentActivity() {
                             requestNotificationPermissionIfNeeded()
                         }
                         viewModel.setAppUpdateAlertsEnabled(enabled)
+                    },
+                    onSetClientCertificateConfig = { uri, password ->
+                        viewModel.setClientCertificateConfig(uri, password)
+                    },
+                    onClearClientCertificateConfig = {
+                        viewModel.clearClientCertificateConfig()
                     },
                     onSetAutomaticAppUpdateChecksEnabled = { enabled ->
                         viewModel.setAutomaticAppUpdateChecksEnabled(enabled)
@@ -977,6 +987,42 @@ class MainActivity : ComponentActivity() {
                         )
                     )
                     viewModel.onPageError("SSL validation failed for this page.", false)
+                }
+
+                override fun onReceivedClientCertRequest(view: WebView?, request: ClientCertRequest?) {
+                    if (view == null || request == null) return
+                    val allowedHosts = viewModel.uiState.value.settings.allowedHosts
+                    if (!ClientCertificateRequestSupport.isAllowedHost(request.host, allowedHosts)) {
+                        DiagnosticsLogger.record(
+                            this@MainActivity,
+                            "client_cert_request_blocked",
+                            mapOf(
+                                "host" to request.host.orEmpty(),
+                                "allowlist" to allowedHosts.joinToString(",")
+                            )
+                        )
+                        request.cancel()
+                        return
+                    }
+                    val cert = ClientCertificateRequestSupport.resolveRequest(
+                        contentResolver = contentResolver,
+                        config = settingsRepository.getClientCertificateConfig(),
+                        request = request,
+                        allowedHosts = allowedHosts
+                    )
+                    if (cert == null) {
+                        DiagnosticsLogger.record(
+                            this@MainActivity,
+                            "client_cert_request_unavailable",
+                            mapOf(
+                                "host" to request.host.orEmpty(),
+                                "configured" to settingsRepository.getClientCertificateConfig().uri.isNullOrBlank().not().toString()
+                            )
+                        )
+                        request.cancel()
+                        return
+                    }
+                    request.proceed(cert.privateKey, cert.certChain)
                 }
             }
 

--- a/app/src/main/java/com/hermeswebui/android/data/ClientCertificateConfig.kt
+++ b/app/src/main/java/com/hermeswebui/android/data/ClientCertificateConfig.kt
@@ -1,0 +1,6 @@
+package com.hermeswebui.android.data
+
+data class ClientCertificateConfig(
+    val uri: String? = null,
+    val password: String? = null
+)

--- a/app/src/main/java/com/hermeswebui/android/data/SettingsRepository.kt
+++ b/app/src/main/java/com/hermeswebui/android/data/SettingsRepository.kt
@@ -20,6 +20,34 @@ class SettingsRepository(context: Context) : SettingsStore {
         EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
     )
 
+    fun getClientCertificateConfig(): ClientCertificateConfig {
+        val uri = sharedPreferences.getString(KEY_CLIENT_CERT_URI, null)?.trim()
+        val password = sharedPreferences.getString(KEY_CLIENT_CERT_PASSWORD, null)?.trim()
+        return ClientCertificateConfig(uri = uri, password = password)
+    }
+
+    fun saveClientCertificateConfig(uri: String?, password: String?) {
+        sharedPreferences.edit {
+            if (uri.isNullOrBlank()) {
+                remove(KEY_CLIENT_CERT_URI)
+            } else {
+                putString(KEY_CLIENT_CERT_URI, uri.trim())
+            }
+            if (password.isNullOrBlank()) {
+                remove(KEY_CLIENT_CERT_PASSWORD)
+            } else {
+                putString(KEY_CLIENT_CERT_PASSWORD, password)
+            }
+        }
+    }
+
+    fun clearClientCertificateConfig() {
+        sharedPreferences.edit {
+            remove(KEY_CLIENT_CERT_URI)
+            remove(KEY_CLIENT_CERT_PASSWORD)
+        }
+    }
+
     init {
         // Migrate away from storing dashboard URLs in Android preferences.
         // Versions before 0.1.5 stored a dashboard URL in SharedPreferences and injected it
@@ -30,7 +58,7 @@ class SettingsRepository(context: Context) : SettingsStore {
 
     private fun runMigration() {
         val lastMigrationVersion = sharedPreferences.getInt(KEY_LAST_MIGRATION_VERSION, 0)
-        val currentMigrationVersion = 12 // Increment this when adding new migrations
+        val currentMigrationVersion = 13 // Increment this when adding new migrations
 
         if (lastMigrationVersion < 1) {
             // Migration 1: Clear dashboard URLs from pre-0.1.5 versions
@@ -119,6 +147,15 @@ class SettingsRepository(context: Context) : SettingsStore {
             val vpnPackage = sharedPreferences.getString(KEY_VPN_LAUNCH_PACKAGE, null)?.trim().orEmpty()
             if (vpnPackage.isBlank()) {
                 sharedPreferences.edit { putString(KEY_VPN_LAUNCH_PACKAGE, DEFAULT_VPN_LAUNCH_PACKAGE) }
+            }
+        }
+
+        if (lastMigrationVersion < 13) {
+            // Migration 13: clear any legacy client-certificate settings so app-level
+            // mTLS handling starts from a known default before the first explicit setup.
+            sharedPreferences.edit {
+                remove(KEY_CLIENT_CERT_URI)
+                remove(KEY_CLIENT_CERT_PASSWORD)
             }
         }
 
@@ -465,6 +502,8 @@ class SettingsRepository(context: Context) : SettingsStore {
         private const val KEY_PENDING_GITHUB_UPDATE_DOWNLOAD_ID = "pending_github_update_download_id"
         private const val KEY_PENDING_GITHUB_UPDATE_CLEANUP_DOWNLOAD_ID = "pending_github_update_cleanup_download_id"
         private const val KEY_AUTH_PROMPT_SILENCED_URLS = "auth_prompt_silenced_urls"
+        private const val KEY_CLIENT_CERT_URI = "client_cert_uri"
+        private const val KEY_CLIENT_CERT_PASSWORD = "client_cert_password"
         private const val KEY_LAST_MIGRATION_VERSION = "last_migration_version"
         private const val DEFAULT_VPN_LAUNCH_PACKAGE = "com.tailscale.ipn"
         private const val DEFAULT_RECONNECT_POLL_INTERVAL_SECONDS = 1

--- a/app/src/main/java/com/hermeswebui/android/security/ClientCertificateRequestSupport.kt
+++ b/app/src/main/java/com/hermeswebui/android/security/ClientCertificateRequestSupport.kt
@@ -1,0 +1,66 @@
+package com.hermeswebui.android.security
+
+import android.content.ContentResolver
+import android.net.Uri
+import androidx.core.net.toUri
+import com.hermeswebui.android.data.ClientCertificateConfig
+import java.security.KeyStore
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+import java.util.Locale
+
+data class ClientCertificate(
+    val privateKey: PrivateKey,
+    val certChain: Array<X509Certificate>
+)
+
+object ClientCertificateRequestSupport {
+    fun isAllowedHost(host: String?, allowedHosts: Set<String>): Boolean {
+        val normalizedHost = host
+            ?.trim()
+            ?.lowercase(Locale.US)
+            ?.takeIf { it.isNotEmpty() }
+            ?: return false
+
+        val normalizedAllowedHosts = allowedHosts
+            .asSequence()
+            .map { it.trim().lowercase(Locale.US) }
+            .filter { it.isNotEmpty() }
+            .toSet()
+
+        return normalizedHost in normalizedAllowedHosts || normalizedAllowedHosts.any { normalizedHost.endsWith(".$it") }
+    }
+
+    fun resolveRequest(
+        contentResolver: ContentResolver,
+        config: ClientCertificateConfig,
+        request: android.webkit.ClientCertRequest,
+        allowedHosts: Set<String>
+    ): ClientCertificate? {
+        val certUri = config.uri?.trim()
+        if (certUri.isNullOrBlank()) return null
+
+        val host = request.host?.trim().orEmpty()
+        if (!isAllowedHost(host, allowedHosts)) return null
+
+        val parsedUri = runCatching { certUri.toUri() }.getOrNull() ?: return null
+        val password = config.password?.trim().orEmpty()
+
+        val keyStore = KeyStore.getInstance("PKCS12")
+        contentResolver.openInputStream(parsedUri)?.use { stream ->
+            keyStore.load(stream, password.toCharArray())
+        } ?: return null
+
+        val aliases = keyStore.aliases()
+        if (!aliases.hasMoreElements()) return null
+
+        val alias = aliases.nextElement()
+        val privateKey = keyStore.getKey(alias, password.toCharArray()) as? PrivateKey ?: return null
+        val chain = keyStore.getCertificateChain(alias)
+            ?.mapNotNull { it as? X509Certificate }
+            ?.toTypedArray()
+            ?: return null
+
+        return ClientCertificate(privateKey = privateKey, certChain = chain)
+    }
+}

--- a/app/src/main/java/com/hermeswebui/android/ui/MainUiState.kt
+++ b/app/src/main/java/com/hermeswebui/android/ui/MainUiState.kt
@@ -40,5 +40,7 @@ data class MainUiState(
     val appUpdateInstallReady: Boolean = false,
     val appUpdateFileName: String? = null,
     val appUpdateReleaseNotes: String? = null,
+    val clientCertificateUri: String? = null,
+    val clientCertificatePassword: String? = null,
     val serverValidation: ServerValidationUiState = ServerValidationUiState()
 )

--- a/app/src/main/java/com/hermeswebui/android/ui/MainViewModel.kt
+++ b/app/src/main/java/com/hermeswebui/android/ui/MainViewModel.kt
@@ -48,7 +48,9 @@ class MainViewModel(
         debugLoggingEnabled = settingsRepositoryImpl?.isDebugLoggingEnabled() ?: false,
         blockScreenshotsEnabled = settingsRepositoryImpl?.isBlockScreenshotsEnabled() ?: false,
         appUpdateAlertsEnabled = settingsRepositoryImpl?.isAppUpdateAlertsEnabled() ?: false,
-        automaticAppUpdateChecksEnabled = settingsRepositoryImpl?.isAutomaticAppUpdateChecksEnabled() ?: false
+        automaticAppUpdateChecksEnabled = settingsRepositoryImpl?.isAutomaticAppUpdateChecksEnabled() ?: false,
+        clientCertificateUri = settingsRepositoryImpl?.getClientCertificateConfig()?.uri,
+        clientCertificatePassword = settingsRepositoryImpl?.getClientCertificateConfig()?.password
     ))
     val uiState: StateFlow<MainUiState> = _uiState.asStateFlow()
 
@@ -431,6 +433,16 @@ class MainViewModel(
         _uiState.update { it.copy(blockScreenshotsEnabled = enabled) }
     }
 
+    fun setClientCertificateConfig(uri: String?, password: String?) {
+        settingsRepositoryImpl?.saveClientCertificateConfig(uri, password)
+        _uiState.update { it.copy(clientCertificateUri = uri, clientCertificatePassword = password) }
+    }
+
+    fun clearClientCertificateConfig() {
+        settingsRepositoryImpl?.clearClientCertificateConfig()
+        _uiState.update { it.copy(clientCertificateUri = null, clientCertificatePassword = null) }
+    }
+
     fun setOAuthInFlowHost(host: String?) {
         if (_uiState.value.oauthInFlowHost == host) return
         _uiState.update { it.copy(oauthInFlowHost = host) }
@@ -520,7 +532,9 @@ class MainViewModel(
                 debugLoggingEnabled = repo.isDebugLoggingEnabled(),
                 blockScreenshotsEnabled = repo.isBlockScreenshotsEnabled(),
                 appUpdateAlertsEnabled = repo.isAppUpdateAlertsEnabled(),
-                automaticAppUpdateChecksEnabled = repo.isAutomaticAppUpdateChecksEnabled()
+                automaticAppUpdateChecksEnabled = repo.isAutomaticAppUpdateChecksEnabled(),
+                clientCertificateUri = repo.getClientCertificateConfig().uri,
+                clientCertificatePassword = repo.getClientCertificateConfig().password
             )
         }
     }

--- a/app/src/main/java/com/hermeswebui/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/hermeswebui/android/ui/settings/SettingsScreen.kt
@@ -94,6 +94,8 @@ fun SettingsScreen(
     appUpdateDownloadUrl: String?,
     appUpdateInstallReady: Boolean,
     appUpdateReleaseNotes: String?,
+    clientCertificateUri: String?,
+    clientCertificatePassword: String?,
     serverValidation: ServerValidationUiState,
     appVersionLabel: String,
     serverProfiles: List<ServerProfile>,
@@ -112,6 +114,8 @@ fun SettingsScreen(
     onSetBlockScreenshotsEnabled: (Boolean) -> Unit,
     onSetAppUpdateAlertsEnabled: (Boolean) -> Unit,
     onSetAutomaticAppUpdateChecksEnabled: (Boolean) -> Unit,
+    onSetClientCertificateConfig: (String?, String?) -> Unit,
+    onClearClientCertificateConfig: () -> Unit,
     onCheckAppUpdates: () -> Unit,
     onDownloadAppUpdate: () -> Unit,
     onOpenAppUpdateRelease: () -> Unit,
@@ -136,6 +140,8 @@ fun SettingsScreen(
     var editCurrentServerWithoutProfile by remember { mutableStateOf(false) }
     var showResetSessionConfirm by remember { mutableStateOf(false) }
     var showVpnAppPickerDialog by remember { mutableStateOf(false) }
+    var clientCertificateUri by remember(clientCertificateUri, isConfigured) { mutableStateOf(clientCertificateUri ?: "") }
+    var clientCertificatePassword by remember(clientCertificatePassword) { mutableStateOf(clientCertificatePassword ?: "") }
     var serverUrl by remember(initialServerUrl, isConfigured) {
         mutableStateOf(if (isConfigured) initialServerUrl else "")
     }
@@ -434,6 +440,78 @@ fun SettingsScreen(
                         serverValidation = serverValidation,
                         modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp)
                     )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // ── Security ───────────────────────────────────────────────
+                SectionHeader("Security")
+
+                Box(
+                    modifier = Modifier
+                        .padding(horizontal = 12.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(surfaceColor)
+                        .fillMaxWidth()
+                ) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Text(
+                            text = "Client certificate for mTLS",
+                            color = onSurface,
+                            fontWeight = FontWeight.Medium
+                        )
+                        Text(
+                            text = "Import a PKCS#12 (.pfx/.p12) or PEM certificate bundle for self-hosted Hermes instances protected by mutual TLS.",
+                            color = onSurfaceVar,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                        OutlinedTextField(
+                            value = clientCertificateUri,
+                            onValueChange = { clientCertificateUri = it },
+                            modifier = Modifier.fillMaxWidth(),
+                            singleLine = true,
+                            label = { Text("Certificate file URI") },
+                            placeholder = { Text("content://... or file:///...") }
+                        )
+                        OutlinedTextField(
+                            value = clientCertificatePassword,
+                            onValueChange = { clientCertificatePassword = it },
+                            modifier = Modifier.fillMaxWidth(),
+                            singleLine = true,
+                            label = { Text("Certificate password") },
+                            placeholder = { Text("Optional for unlocked certs") }
+                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            Button(
+                                onClick = {
+                                    onSetClientCertificateConfig(clientCertificateUri.trim().ifBlank { null }, clientCertificatePassword.trim().ifBlank { null })
+                                },
+                                modifier = Modifier.weight(1f),
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = primaryColor,
+                                    contentColor = MaterialTheme.colorScheme.onPrimary
+                                )
+                            ) {
+                                Text("Save certificate")
+                            }
+                            OutlinedButton(
+                                onClick = {
+                                    clientCertificateUri = ""
+                                    clientCertificatePassword = ""
+                                    onClearClientCertificateConfig()
+                                },
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                Text("Clear")
+                            }
+                        }
+                    }
                 }
 
                 Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/test/java/com/hermeswebui/android/ClientCertificateRequestSupportTest.kt
+++ b/app/src/test/java/com/hermeswebui/android/ClientCertificateRequestSupportTest.kt
@@ -1,0 +1,17 @@
+package com.hermeswebui.android
+
+import com.google.common.truth.Truth.assertThat
+import com.hermeswebui.android.security.ClientCertificateRequestSupport
+import org.junit.Test
+
+class ClientCertificateRequestSupportTest {
+    @Test
+    fun `server host must match the app allowlist before prompting for a client certificate`() {
+        val allowlist = setOf("hermes.example.com", "localhost")
+
+        assertThat(ClientCertificateRequestSupport.isAllowedHost("hermes.example.com", allowlist)).isTrue()
+        assertThat(ClientCertificateRequestSupport.isAllowedHost("localhost", allowlist)).isTrue()
+        assertThat(ClientCertificateRequestSupport.isAllowedHost("evil.example.com", allowlist)).isFalse()
+        assertThat(ClientCertificateRequestSupport.isAllowedHost("", allowlist)).isFalse()
+    }
+}


### PR DESCRIPTION
## What changed

This fixes the Android WebView mTLS failure for Hermes servers behind Cloudflare Tunnel when the upstream service requires a client certificate.

- Added an Android WebView `onReceivedClientCertRequest` hook in `MainActivity`.
- Added allowlist-guarded PKCS#12 certificate resolution in `ClientCertificateRequestSupport`.
- Persisted the client certificate URI/password through encrypted settings so it survives app restarts.
- Added a focused unit regression test covering the allowed-host certificate gate.
- Added a native Settings section to save/clear the certificate config for mTLS-protected servers.

## Testing

- `./gradlew.bat testDebugUnitTest --no-daemon`
- `./gradlew.bat assembleDebug --no-daemon`

Fixes #73
