### PR TITLE
Update Android CI actions for Node 24

### DIFF
--- a/.github/workflows/0-ci-build-and-test.yml
+++ b/.github/workflows/0-ci-build-and-test.yml
@@ -56,7 +56,9 @@ jobs:
         run: |
           sdkmanager="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
           test -x "$sdkmanager" || { echo "Android SDK manager is unavailable"; exit 1; }
+          set +o pipefail
           yes | "$sdkmanager" --licenses > /dev/null
+          set -o pipefail
           "$sdkmanager" --install "platforms;android-37" "platform-tools"
 
       - name: Set up Gradle
@@ -95,7 +97,9 @@ jobs:
         run: |
           sdkmanager="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
           test -x "$sdkmanager" || { echo "Android SDK manager is unavailable"; exit 1; }
+          set +o pipefail
           yes | "$sdkmanager" --licenses > /dev/null
+          set -o pipefail
           "$sdkmanager" --install "platforms;android-37" "platform-tools"
 
       - name: Set up Gradle

--- a/.github/workflows/0-ci-build-and-test.yml
+++ b/.github/workflows/0-ci-build-and-test.yml
@@ -59,7 +59,6 @@ jobs:
           set +o pipefail
           yes | "$sdkmanager" --licenses > /dev/null
           set -o pipefail
-          "$sdkmanager" --install "platforms;android-37" "platform-tools"
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2 # v5.0.0
@@ -100,7 +99,6 @@ jobs:
           set +o pipefail
           yes | "$sdkmanager" --licenses > /dev/null
           set -o pipefail
-          "$sdkmanager" --install "platforms;android-37" "platform-tools"
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2 # v5.0.0

--- a/.github/workflows/0-ci-build-and-test.yml
+++ b/.github/workflows/0-ci-build-and-test.yml
@@ -24,11 +24,11 @@ jobs:
     outputs:
       settings_ui: ${{ steps.filter.outputs.settings_ui }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Detect Settings UI changes
         id: filter
-        uses: dorny/paths-filter@15192bc058cc28a13dbf6cde61f19e18988b7af6 # v3.0.2
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         with:
           filters: |
             settings_ui:
@@ -43,19 +43,24 @@ jobs:
     name: Unit tests + debug build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.0.0
         with:
           distribution: temurin
           java-version: "17"
 
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
+      - name: Prepare Android SDK
+        shell: bash
+        run: |
+          sdkmanager="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+          test -x "$sdkmanager" || { echo "Android SDK manager is unavailable"; exit 1; }
+          yes | "$sdkmanager" --licenses > /dev/null
+          "$sdkmanager" --install "platforms;android-37" "platform-tools"
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4.4.3
+        uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2 # v5.0.0
 
       - name: Unit tests
         run: ./gradlew --no-daemon testDebugUnitTest
@@ -65,7 +70,7 @@ jobs:
 
       - name: Upload debug APK
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: hermes-debug-apk
           path: app/build/outputs/apk/debug/*.apk
@@ -77,19 +82,24 @@ jobs:
     if: github.event_name == 'pull_request' && needs.changes.outputs.settings_ui == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.0.0
         with:
           distribution: temurin
           java-version: "17"
 
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
+      - name: Prepare Android SDK
+        shell: bash
+        run: |
+          sdkmanager="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+          test -x "$sdkmanager" || { echo "Android SDK manager is unavailable"; exit 1; }
+          yes | "$sdkmanager" --licenses > /dev/null
+          "$sdkmanager" --install "platforms;android-37" "platform-tools"
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4.4.3
+        uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2 # v5.0.0
 
       - name: Run focused Settings screen instrumentation
         uses: reactivecircus/android-emulator-runner@4c44018e59b437e86cdfc41da381398f93ed8808 # v2.38.0


### PR DESCRIPTION
## What changed

Updates the CI workflow to remove GitHub Actions Node.js 20 deprecation warnings.

- upgrades and pins checkout to v7, paths-filter to v4, setup-java to v5, setup-gradle to v5, and upload-artifact to v6
- replaces the deprecated Android SDK setup action with runner-native Android SDK license preparation
- preserves the selective Settings emulator smoke-test policy and existing CI behavior

## Testing

- VS Code YAML diagnostics: no errors
- `git -c core.whitespace=cr-at-eol diff --check -- .github/workflows/0-ci-build-and-test.yml`

GitHub Actions will validate the updated workflow on this PR.
