### PR TITLE
Suppress auth-required toast during configured startup

### DIFF
--- a/app/src/main/java/com/hermeswebui/android/server/HermesServerProfileCoordinator.kt
+++ b/app/src/main/java/com/hermeswebui/android/server/HermesServerProfileCoordinator.kt
@@ -13,6 +13,14 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
+internal enum class ServerValidationFlow {
+    CONFIGURED_STARTUP,
+    PERSISTENCE
+}
+
+internal fun shouldShowAuthRequiredToast(flow: ServerValidationFlow): Boolean =
+    flow == ServerValidationFlow.PERSISTENCE
+
 class HermesServerProfileCoordinator(
     private val context: Context,
     private val activityScope: CoroutineScope,
@@ -32,6 +40,7 @@ class HermesServerProfileCoordinator(
         validateServerBeforePersist(
             serverUrl = serverUrl,
             openSettingsOnFailure = true,
+            validationFlow = ServerValidationFlow.CONFIGURED_STARTUP,
             onFailure = null
         ) {
             onContinueToWebView(startUrl)
@@ -362,6 +371,7 @@ class HermesServerProfileCoordinator(
     private fun validateServerBeforePersist(
         serverUrl: String,
         openSettingsOnFailure: Boolean = false,
+        validationFlow: ServerValidationFlow = ServerValidationFlow.PERSISTENCE,
         onFailure: ((HermesApiClient.ServerReadinessResult) -> Unit)? = null,
         onSuccess: () -> Unit
     ) {
@@ -398,11 +408,13 @@ class HermesServerProfileCoordinator(
                     mapOf("origin" to DiagnosticsLogger.originOnly(serverUrl))
                 )
                 viewModel.clearServerValidationState()
-                Toast.makeText(
-                    context,
-                    "Server reachable — sign in on the Hermes page to finish.",
-                    Toast.LENGTH_LONG
-                ).show()
+                if (shouldShowAuthRequiredToast(validationFlow)) {
+                    Toast.makeText(
+                        context,
+                        "Server reachable — sign in on the Hermes page to finish.",
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
                 onSuccess()
                 return@launch
             }

--- a/app/src/test/java/com/hermeswebui/android/server/HermesServerProfileCoordinatorTest.kt
+++ b/app/src/test/java/com/hermeswebui/android/server/HermesServerProfileCoordinatorTest.kt
@@ -1,0 +1,16 @@
+package com.hermeswebui.android.server
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class HermesServerProfileCoordinatorTest {
+    @Test
+    fun `configured startup does not show auth-required toast`() {
+        assertThat(shouldShowAuthRequiredToast(ServerValidationFlow.CONFIGURED_STARTUP)).isFalse()
+    }
+
+    @Test
+    fun `persistence flow still shows auth-required toast`() {
+        assertThat(shouldShowAuthRequiredToast(ServerValidationFlow.PERSISTENCE)).isTrue()
+    }
+}


### PR DESCRIPTION
## Problem

Auth-protected Hermes servers return `401`/`403` to the native `/api/status` probe because it does not share the WebView session cookie. The configured-server startup preflight correctly soft-passes and loads the WebView, but it also reuses the persistence-flow toast:

> Server reachable — sign in on the Hermes page to finish.

For users who are already signed in, this produces a misleading toast on every app launch. Reproduced on phone and tablet with the v1.0.29 GitHub build.

## Change

- Distinguish configured startup validation from add/edit persistence validation.
- Suppress the auth-required toast only during configured startup.
- Preserve the toast for add/edit flows where sign-in guidance is useful.
- Add regression coverage for both flow decisions.

Authentication, readiness handling, WebView loading, and server persistence behavior are unchanged.

## Verification

- Regression test sabotage run: the startup test fails when toast behavior is forced back on.
- `./gradlew app:testDebugUnitTest app:lintDebug app:assembleDebug --no-daemon`
- Result: `BUILD SUCCESSFUL` (53 tasks).
