### PR TITLE
Fix release orchestration metadata generation

### DIFF
--- a/.github/workflows/1-orchestration-release.yml
+++ b/.github/workflows/1-orchestration-release.yml
@@ -7,7 +7,7 @@ on:
       - 'v*'
 
 permissions:
-  contents: read
+  contents: write
   actions: read
 
 concurrency:

--- a/tools/tests/test_workflow_contracts.py
+++ b/tools/tests/test_workflow_contracts.py
@@ -66,6 +66,7 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertEqual(generators, ["1-orchestration-release.yml"])
 
         orchestrator = workflows["1-orchestration-release.yml"]
+        self.assertIn("permissions:\n  contents: write\n  actions: read", orchestrator)
         self.assertIn("tools/generate_release_metadata.py", orchestrator)
         self.assertIn("build/release/release-notes.md", orchestrator)
         self.assertIn("build/release/play-whatsnew/whatsnew-en-US", orchestrator)


### PR DESCRIPTION
## What changed
- The orchestration build job restores contents: write so GitHub can generate release notes.

## Testing
- python -m unittest discover -s tools/tests -p 'test_*.py' -v (15 passed)