### PR TITLE
Add CI guards for injected WebUI JavaScript and report each check separately

### DIFF
--- a/.github/workflows/0-ci-build-and-test.yml
+++ b/.github/workflows/0-ci-build-and-test.yml
@@ -1,9 +1,8 @@
 name: 0 - CI Build & Test
 
-# Build + unit-test gate for pushes and PRs. The repo previously had only the
-# signed-release workflows (1/2/3-*), so nothing compiled or tested changes on a
-# PR before merge. This adds that missing feedback loop without needing any
-# signing secrets (debug build only).
+# Build + quality gate for pushes and PRs. Every check runs as its own job so a
+# red X names the thing that broke (unit tests vs. Android Lint vs. injected-JS
+# syntax) instead of collapsing several gates into one opaque failure.
 on:
   push:
     branches: ["main"]
@@ -21,6 +20,7 @@ jobs:
   changes:
     name: Detect Android app changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       android_app: ${{ steps.filter.outputs.android_app }}
     steps:
@@ -41,9 +41,128 @@ jobs:
               - 'gradle/libs.versions.toml'
               - '.github/workflows/0-ci-build-and-test.yml'
 
-  build:
-    name: Quality gates + debug build
+  release-tooling-tests:
+    name: Release tooling tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run release tooling unit tests
+        run: python3 -m unittest discover -s tools/tests -p 'test_*.py' -v
+
+  # The WebUI shims live inside Kotlin raw strings, so kotlinc and Android Lint
+  # never parse them. A syntax error or a runtime-only mistake there ships a
+  # green build that bricks WebUI rendering on device. These two jobs extract the
+  # scripts and check them as real JavaScript.
+  webui-script-syntax:
+    name: Injected WebUI JS - syntax
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Extract injected WebUI scripts
+        run: python3 tools/extract_webui_scripts.py
+
+      - name: Syntax-check each injected script
+        run: |
+          set -uo pipefail
+          failed=0
+          for script in build/webui-scripts/*.js; do
+            if node --check "$script"; then
+              echo "ok: $script"
+            else
+              echo "::error file=$script::Injected WebUI script failed to parse"
+              failed=1
+            fi
+          done
+          exit "$failed"
+
+      - name: Upload extracted scripts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: hermes-webui-extracted-scripts
+          path: build/webui-scripts/
+          if-no-files-found: warn
+
+  webui-script-lint:
+    name: Injected WebUI JS - runtime guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Extract injected WebUI scripts
+        run: python3 tools/extract_webui_scripts.py
+
+      - name: Install ESLint
+        run: npm install --no-save --no-audit --no-fund eslint@^10
+
+      - name: ESLint runtime-error gate
+        run: npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "build/webui-scripts/**/*.js"
+
+  unit-tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.0.0
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2 # v5.0.0
+
+      - name: Run unit tests
+        run: ./gradlew --no-daemon testDebugUnitTest
+
+      - name: Upload unit test reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: hermes-unit-test-reports
+          path: |
+            app/build/reports/tests/testDebugUnitTest/
+            app/build/test-results/testDebugUnitTest/
+          if-no-files-found: warn
+
+  android-lint:
+    name: Android Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.0.0
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2 # v5.0.0
+
+      - name: Run Android Lint
+        run: ./gradlew --no-daemon lintDebug
+
+      - name: Upload lint report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: hermes-lint-report
+          path: app/build/reports/lint-results-debug.*
+          if-no-files-found: warn
+
+  debug-build:
+    name: Debug APK build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -65,22 +184,8 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2 # v5.0.0
 
-      - name: Test release tooling
-        run: python3 -m unittest discover -s tools/tests -p 'test_*.py' -v
-
-      - name: Unit tests, Android Lint, and debug APK
-        run: ./gradlew --no-daemon testDebugUnitTest lintDebug assembleDebug
-
-      - name: Upload QA reports
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: hermes-debug-qa-reports
-          path: |
-            app/build/reports/tests/testDebugUnitTest/
-            app/build/test-results/testDebugUnitTest/
-            app/build/reports/lint-results-debug.*
-          if-no-files-found: warn
+      - name: Assemble debug APK
+        run: ./gradlew --no-daemon assembleDebug
 
       - name: Upload debug APK
         if: success()
@@ -95,6 +200,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.android_app == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ app/release/
 /keystore.properties
 /signing/
 /gradle-*.log
+
+# ESLint runtime guard for injected WebUI scripts installs on demand.
+/node_modules/
+/package-lock.json
+.eslintcache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,18 @@ and ends with:
 Keep `RELEASE.md` aligned with the workflow operator path whenever release
 automation changes.
 
-Separate from release publishing, CI uses `.github/workflows/0-ci-build-and-test.yml` to run release-tool tests plus `testDebugUnitTest` + `lintDebug` + `assembleDebug` on pull requests and direct `main` pushes without signing secrets. Pull requests and direct `main` pushes that change Android source or build inputs run the complete unfiltered `connectedDebugAndroidTest` suite on Android API 35 and 36. Release builds run the full API 36 suite again, then verify APK and AAB signatures before upload. Keep contributor verification steps aligned with these gates when changing build/test flow.
+Separate from release publishing, CI uses `.github/workflows/0-ci-build-and-test.yml` to gate pull requests and direct `main` pushes without signing secrets. Each check runs as its own job so a failure names the gate that broke: `release-tooling-tests`, `webui-script-syntax`, `webui-script-lint`, `unit-tests`, `android-lint`, and `debug-build`. Keep every job's `timeout-minutes` set; an untimed job can burn the six-hour runner default. Pull requests and direct `main` pushes that change Android source or build inputs also run the complete unfiltered `connectedDebugAndroidTest` suite on Android API 35 and 36. Release builds run the full API 36 suite again, then verify APK and AAB signatures before upload. Keep contributor verification steps aligned with these gates when changing build/test flow.
+
+The injected WebUI JavaScript in `webui/HermesWebUiScripts.kt` (and the raw-string block in `MainActivity.kt`) is invisible to kotlinc and Android Lint, so a syntax error or runtime-only mistake there ships green and bricks WebUI rendering on device. `tools/extract_webui_scripts.py` pulls each Kotlin raw string out into a standalone `.js` file — padded so JavaScript line numbers match the Kotlin source, with Kotlin string templates replaced by a placeholder literal — and CI runs `node --check` plus `eslint.runtime-guard.config.mjs` over the result. That ESLint config is deliberately not a style linter: it enables only rules that catch code which parses but throws at runtime. Add a Kotlin file to `SOURCE_FILES` in the extractor when it starts carrying injected script text, and add genuinely WebUI-owned page globals to `webUiPageGlobals` rather than disabling `no-undef`.
+
+Run the same guards locally with:
+
+```powershell
+python tools/extract_webui_scripts.py
+Get-ChildItem build/webui-scripts/*.js | ForEach-Object { node --check $_.FullName }
+npm install --no-save eslint@^10
+npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "build/webui-scripts/**/*.js"
+```
 
 ## Verification
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -126,6 +126,7 @@ sketches are captured inline below.
 
 | ID | Date | Area | Summary |
 |---|---|---|---|
+| TEST-004 | 2026-08-26 | CI / Testing | Split PR CI into per-check jobs (release tooling, unit tests, Android Lint, debug APK) so a failure names the gate that broke, added job timeouts, and introduced syntax plus ESLint runtime-error gates for the JavaScript Android injects into the WebUI WebView. |
 | REL-028 | 2026-08-26 | Release / CI | Reworked release orchestration to build immutable reviewed versions, pin external actions, generate linked GitHub/Play changelogs once, validate retry metadata against the originating run, and verify APK/AAB signatures before publishing. |
 | TEST-003 | 2026-08-26 | CI / Testing | Expanded QA with release-tool/workflow contract tests, Android API 35/36 instrumentation gates, share/deep-link/manifest/notification contracts, duplicate-profile rules, and deterministic GitHub update parsing. |
 | BUG-048 | 2026-08-26 | Settings | Prevented profile edits from creating duplicate server names or normalized URLs, matching the existing add-server invariant. |

--- a/eslint.runtime-guard.config.mjs
+++ b/eslint.runtime-guard.config.mjs
@@ -1,0 +1,107 @@
+// Runtime-error guard for the JavaScript that Android injects into the Hermes
+// WebUI WebView (see tools/extract_webui_scripts.py).
+//
+// Deliberately NOT a style linter: no formatting, naming, or complexity rules.
+// It enables only the rules that catch code which parses fine but throws when a
+// real WebView executes it — the class of bug that bricks WebUI rendering on
+// device while every Kotlin unit test and Android Lint check stays green.
+
+const browserGlobals = [
+  "AbortController",
+  "Blob",
+  "CSS",
+  "CustomEvent",
+  "DOMException",
+  "Date",
+  "Element",
+  "Event",
+  "FormData",
+  "Headers",
+  "HTMLElement",
+  "Image",
+  "JSON",
+  "Math",
+  "MediaRecorder",
+  "MutationObserver",
+  "Node",
+  "NodeFilter",
+  "Notification",
+  "Promise",
+  "Request",
+  "Response",
+  "ResizeObserver",
+  "ServiceWorkerRegistration",
+  "URL",
+  "URLSearchParams",
+  "cancelAnimationFrame",
+  "clearInterval",
+  "clearTimeout",
+  "console",
+  "document",
+  "fetch",
+  "getComputedStyle",
+  "localStorage",
+  "location",
+  "navigator",
+  "queueMicrotask",
+  "requestAnimationFrame",
+  "screen",
+  "self",
+  "sessionStorage",
+  "setInterval",
+  "setTimeout",
+  "visualViewport",
+  "window",
+];
+
+// Globals owned by the Hermes WebUI page itself, not by Android. The shims read
+// them defensively (`typeof x !== 'undefined'`) because WebUI may rename or drop
+// them; list them here so no-undef stays meaningful for genuine typos.
+const webUiPageGlobals = ["_clarifyId", "_clarifySignature"];
+
+const globals = Object.fromEntries(
+  [...browserGlobals, ...webUiPageGlobals].map((name) => [name, "readonly"]),
+);
+
+export default [
+  {
+    files: ["**/*.js"],
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: "script",
+      globals,
+    },
+    linterOptions: {
+      reportUnusedDisableDirectives: true,
+    },
+    rules: {
+      // Assignment/binding errors that throw only at execution time.
+      "no-const-assign": "error",
+      "no-import-assign": "error",
+      "no-func-assign": "error",
+      "no-class-assign": "error",
+      "no-self-assign": "error",
+
+      // References that resolve to nothing once the browser runs the script.
+      "no-undef": "error",
+      "no-obj-calls": "error",
+      "no-unreachable": "error",
+
+      // Silent-wrong-behavior traps.
+      "no-dupe-args": "error",
+      "no-dupe-keys": "error",
+      "no-dupe-class-members": "error",
+      "no-duplicate-case": "error",
+      "no-unsafe-negation": "error",
+      "no-unsafe-finally": "error",
+      "no-compare-neg-zero": "error",
+      "use-isnan": "error",
+      "valid-typeof": "error",
+
+      // Declaration hazards specific to the classic-script scope these run in.
+      "no-redeclare": "error",
+      "no-undef-init": "off",
+      "no-sparse-arrays": "error",
+    },
+  },
+];

--- a/tools/extract_webui_scripts.py
+++ b/tools/extract_webui_scripts.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Extract the JavaScript that Android injects into the Hermes WebUI WebView.
+
+The injected shims (viewport polyfill, mic fallback, Enter-key shim, sidebar
+settings injector, notification bridge, route recovery) live inside Kotlin raw
+strings, so the Kotlin compiler and Android Lint only ever see them as opaque
+text. A typo, a `const` reassignment, or a reference to an undefined helper
+compiles clean and only throws once a real WebView executes the page.
+
+This script pulls each raw-string block out into a standalone `.js` file so
+`node --check` and ESLint can inspect it. Extracted files are padded with blank
+lines so that JavaScript line N maps to Kotlin line N, which keeps parser and
+linter diagnostics pointing at the real source location.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Kotlin sources that embed injected WebView JavaScript. Every raw string in
+# these files is treated as JavaScript; add a file here when it starts carrying
+# injected script text.
+SOURCE_FILES = (
+    "app/src/main/java/com/hermeswebui/android/webui/HermesWebUiScripts.kt",
+    "app/src/main/java/com/hermeswebui/android/MainActivity.kt",
+)
+
+RAW_DELIMITER = '"""'
+DECLARATION_RE = re.compile(r"\b(?:val|var|fun)\s+([A-Za-z_][A-Za-z0-9_]*)")
+# Indentation of a top-level member inside an `object`/`class` body.
+MEMBER_INDENT = 4
+# Kotlin string templates: `${expr}` or `$identifier`.
+INTERPOLATION_RE = re.compile(r"\$\{[^{}]*\}|\$[A-Za-z_][A-Za-z0-9_]*")
+# Interpolated values are always JSON-quoted strings or booleans at the call
+# site, so a string literal is a faithful stand-in for syntax/lint purposes.
+INTERPOLATION_PLACEHOLDER = '"__HERMES_KOTLIN_INTERPOLATION__"'
+
+
+class ExtractionError(RuntimeError):
+    pass
+
+
+def trim_indent(text: str) -> str:
+    """Approximate Kotlin's `String.trimIndent()` for raw-string blocks."""
+    lines = text.split("\n")
+    indents = [len(line) - len(line.lstrip()) for line in lines if line.strip()]
+    margin = min(indents) if indents else 0
+    return "\n".join(line[margin:] if line.strip() else "" for line in lines)
+
+
+def find_raw_string_blocks(source: str) -> list[tuple[int, str]]:
+    """Return `(zero-based start line, block body)` for each Kotlin raw string."""
+    delimiters = []
+    index = source.find(RAW_DELIMITER)
+    while index != -1:
+        delimiters.append(index)
+        index = source.find(RAW_DELIMITER, index + len(RAW_DELIMITER))
+
+    if len(delimiters) % 2 != 0:
+        raise ExtractionError("unbalanced raw-string delimiters")
+
+    blocks = []
+    for open_index, close_index in zip(delimiters[0::2], delimiters[1::2]):
+        body_start = open_index + len(RAW_DELIMITER)
+        body = source[body_start:close_index]
+        start_line = source.count("\n", 0, body_start)
+        blocks.append((start_line, body))
+    return blocks
+
+
+def declaration_name(source: str, block_start_line: int, fallback: str) -> str:
+    """Name a block after the enclosing member declaration.
+
+    Scanning backwards finds the nearest `val`/`fun`, but a builder function
+    declares locals (`val quotedUrl = ...`) just above its returned raw string.
+    Preferring the least-indented declaration walks out of those locals and up
+    to the member that callers actually reference.
+    """
+    lines = source.split("\n")
+    best_name = fallback
+    best_indent = None
+    for line in reversed(lines[: block_start_line + 1]):
+        match = DECLARATION_RE.search(line)
+        if not match:
+            continue
+        indent = len(line) - len(line.lstrip())
+        if best_indent is None or indent < best_indent:
+            best_name, best_indent = match.group(1), indent
+        if indent <= MEMBER_INDENT:
+            break
+    return best_name
+
+
+def extract_file(path: Path) -> list[tuple[str, str]]:
+    """Return `(output file name, JavaScript text)` for one Kotlin source file."""
+    source = path.read_text(encoding="utf-8")
+    results = []
+    for ordinal, (start_line, body) in enumerate(find_raw_string_blocks(source), start=1):
+        script = INTERPOLATION_RE.sub(INTERPOLATION_PLACEHOLDER, trim_indent(body))
+        name = declaration_name(source, start_line, fallback=f"block{ordinal}")
+        # Pad so JS line numbers match the Kotlin file the block came from. The
+        # body keeps its own leading newline, which accounts for content that
+        # starts on the line after the opening delimiter.
+        padded = "\n" * start_line + script
+        results.append((f"{path.stem}.{name}.js", padded))
+    return results
+
+
+def extract_all(root: Path, out_dir: Path) -> list[Path]:
+    if out_dir.exists():
+        shutil.rmtree(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    written = []
+    for relative in SOURCE_FILES:
+        path = root / relative
+        if not path.exists():
+            raise ExtractionError(f"missing source file: {relative}")
+        for name, script in extract_file(path):
+            target = out_dir / name
+            if target.exists():
+                raise ExtractionError(f"duplicate extracted script name: {name}")
+            target.write_text(script, encoding="utf-8")
+            written.append(target)
+
+    if not written:
+        raise ExtractionError("no injected scripts were extracted")
+    return written
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out-dir",
+        default="build/webui-scripts",
+        help="directory to write extracted .js files into (recreated on each run)",
+    )
+    parser.add_argument("--root", default=str(ROOT), help="repository root")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    out_dir = Path(args.out_dir)
+    if not out_dir.is_absolute():
+        out_dir = root / out_dir
+
+    try:
+        written = extract_all(root, out_dir)
+    except ExtractionError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    for path in written:
+        print(path.relative_to(root).as_posix())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_extract_webui_scripts.py
+++ b/tools/tests/test_extract_webui_scripts.py
@@ -1,0 +1,124 @@
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from extract_webui_scripts import (  # noqa: E402
+    SOURCE_FILES,
+    ExtractionError,
+    declaration_name,
+    extract_all,
+    extract_file,
+    find_raw_string_blocks,
+    trim_indent,
+)
+
+
+SAMPLE_KOTLIN = '''package com.example
+
+object Sample {
+    val firstScript = """
+        (function() {
+          var a = 1;
+        })();
+    """.trimIndent()
+
+    fun buildSecond(url: String): String {
+        val quotedUrl = JSONObject.quote(url)
+        return """
+            (function() {
+              var target = $quotedUrl;
+            })();
+        """.trimIndent()
+    }
+}
+'''
+
+
+class TrimIndentTests(unittest.TestCase):
+    def test_strips_the_common_margin_and_blanks_whitespace_only_lines(self) -> None:
+        text = "\n        a\n\n          b\n        "
+        self.assertEqual(trim_indent(text), "\na\n\n  b\n")
+
+
+class RawStringScanTests(unittest.TestCase):
+    def test_finds_each_block_with_its_start_line(self) -> None:
+        blocks = find_raw_string_blocks(SAMPLE_KOTLIN)
+        self.assertEqual(len(blocks), 2)
+        self.assertEqual([start for start, _ in blocks], [3, 11])
+
+    def test_unbalanced_delimiters_are_rejected(self) -> None:
+        with self.assertRaises(ExtractionError):
+            find_raw_string_blocks('val a = """ oops')
+
+
+class DeclarationNameTests(unittest.TestCase):
+    def test_uses_the_property_name_for_a_plain_val_block(self) -> None:
+        self.assertEqual(declaration_name(SAMPLE_KOTLIN, 3, "fallback"), "firstScript")
+
+    def test_prefers_the_enclosing_function_over_a_local_val(self) -> None:
+        self.assertEqual(declaration_name(SAMPLE_KOTLIN, 11, "fallback"), "buildSecond")
+
+
+class ExtractFileTests(unittest.TestCase):
+    def _extract_sample(self) -> dict[str, str]:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "Sample.kt"
+            path.write_text(SAMPLE_KOTLIN, encoding="utf-8")
+            return dict(extract_file(path))
+
+    def test_names_each_output_after_its_source_and_declaration(self) -> None:
+        self.assertEqual(
+            sorted(self._extract_sample()),
+            ["Sample.buildSecond.js", "Sample.firstScript.js"],
+        )
+
+    def test_kotlin_interpolation_becomes_a_valid_js_literal(self) -> None:
+        script = self._extract_sample()["Sample.buildSecond.js"]
+        self.assertNotIn("$quotedUrl", script)
+        self.assertIn('var target = "__HERMES_KOTLIN_INTERPOLATION__";', script)
+
+    def test_padding_keeps_js_line_numbers_aligned_with_kotlin(self) -> None:
+        script = self._extract_sample()["Sample.firstScript.js"]
+        lines = script.split("\n")
+        # `(function() {` sits on Kotlin line 5, so it must land on JS line 5.
+        self.assertEqual(lines[4], "(function() {")
+        self.assertEqual(lines[:4], ["", "", "", ""])
+
+
+class RepositoryExtractionTests(unittest.TestCase):
+    def test_every_declared_source_file_exists(self) -> None:
+        missing = [name for name in SOURCE_FILES if not (ROOT / name).exists()]
+        self.assertEqual(missing, [])
+
+    def test_extraction_produces_the_known_injected_scripts(self) -> None:
+        with TemporaryDirectory() as tmp:
+            written = extract_all(ROOT, Path(tmp))
+            names = {path.name for path in written}
+        for expected in (
+            "HermesWebUiScripts.viewportFixScript.js",
+            "HermesWebUiScripts.microphoneFallbackScript.js",
+            "HermesWebUiScripts.enterKeyNewlineScript.js",
+            "HermesWebUiScripts.appSettingsEntryScript.js",
+            "HermesWebUiScripts.suppressClarifyAutofocusScript.js",
+            "HermesWebUiScripts.buildRouteRecoveryScript.js",
+            "HermesWebUiScripts.buildNotificationBridgeScript.js",
+        ):
+            self.assertIn(expected, names)
+
+    def test_extracted_scripts_contain_no_kotlin_interpolation(self) -> None:
+        with TemporaryDirectory() as tmp:
+            for path in extract_all(ROOT, Path(tmp)):
+                text = path.read_text(encoding="utf-8")
+                self.assertNotRegex(
+                    text,
+                    r"\$\{|\$[A-Za-z_]",
+                    msg=f"{path.name} still carries Kotlin string-template syntax",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_workflow_contracts.py
+++ b/tools/tests/test_workflow_contracts.py
@@ -38,13 +38,46 @@ class WorkflowContractTests(unittest.TestCase):
     def test_ci_runs_tooling_quality_and_android_15_16_contracts(self) -> None:
         workflow = read_workflow("0-ci-build-and-test.yml")
         self.assertIn("python3 -m unittest discover -s tools/tests", workflow)
-        self.assertIn("testDebugUnitTest lintDebug assembleDebug", workflow)
         self.assertIn('branches: ["main"]', workflow)
         self.assertIn("pull_request:", workflow)
         self.assertRegex(workflow, r"api-level:\s*\[35, 36\]")
         self.assertIn("connectedDebugAndroidTest", workflow)
         self.assertNotIn("testInstrumentationRunnerArguments.class", workflow)
         self.assertIn("if: needs.changes.outputs.android_app == 'true'", workflow)
+
+    def test_ci_reports_each_quality_gate_as_its_own_job(self) -> None:
+        workflow = read_workflow("0-ci-build-and-test.yml")
+        for job, command in (
+            ("release-tooling-tests:", "python3 -m unittest discover -s tools/tests"),
+            ("unit-tests:", "./gradlew --no-daemon testDebugUnitTest"),
+            ("android-lint:", "./gradlew --no-daemon lintDebug"),
+            ("debug-build:", "./gradlew --no-daemon assembleDebug"),
+        ):
+            self.assertIn(f"\n  {job}\n", workflow)
+            self.assertIn(command, workflow)
+        # A combined invocation hides which gate failed.
+        self.assertNotIn("testDebugUnitTest lintDebug assembleDebug", workflow)
+
+    def test_ci_guards_the_javascript_android_injects_into_the_webview(self) -> None:
+        workflow = read_workflow("0-ci-build-and-test.yml")
+        self.assertIn("\n  webui-script-syntax:\n", workflow)
+        self.assertIn("\n  webui-script-lint:\n", workflow)
+        self.assertIn("python3 tools/extract_webui_scripts.py", workflow)
+        self.assertIn("node --check", workflow)
+        self.assertIn("eslint.runtime-guard.config.mjs", workflow)
+        self.assertTrue((ROOT / "tools" / "extract_webui_scripts.py").exists())
+        self.assertTrue((ROOT / "eslint.runtime-guard.config.mjs").exists())
+
+    def test_every_ci_job_declares_a_timeout(self) -> None:
+        workflow = read_workflow("0-ci-build-and-test.yml")
+        jobs_section = workflow.split("\njobs:\n", 1)[1]
+        jobs = re.findall(r"^  ([a-z0-9-]+):$", jobs_section, re.MULTILINE)
+        self.assertGreater(len(jobs), 1)
+        blocks = re.split(r"^  [a-z0-9-]+:$", jobs_section, flags=re.MULTILINE)[1:]
+        missing = [
+            job for job, block in zip(jobs, blocks) if "timeout-minutes:" not in block
+        ]
+        self.assertEqual(missing, [])
 
     def test_orchestrator_builds_reviewed_version_without_source_mutation(self) -> None:
         workflow = read_workflow("1-orchestration-release.yml")


### PR DESCRIPTION
## What changed

### Injected WebUI JavaScript is now checked as JavaScript

The shims Android injects into the WebUI WebView — the hybrid viewport polyfill,
microphone fallback, Enter-key newline shim, sidebar settings injector, Clarify
autofocus suppressor, notification bridge, and route recovery — live inside
Kotlin raw strings. Neither kotlinc nor Android Lint parses them, so a syntax
error or a runtime-only mistake compiles clean, ships green, and bricks WebUI
rendering on device.

- `tools/extract_webui_scripts.py` extracts each Kotlin raw string into a
  standalone `.js` file. Output is padded with blank lines so JavaScript line
  numbers match the Kotlin source, and Kotlin string templates are replaced with
  a placeholder literal, so parser and linter diagnostics point at the real
  location in the `.kt` file.
- `eslint.runtime-guard.config.mjs` is deliberately **not** a style linter. It
  enables only rules that catch code which parses but throws at execution time:
  `no-const-assign`, `no-func-assign`, `no-undef`, `no-obj-calls`, `no-dupe-*`,
  `valid-typeof`, and friends.
- Two new CI jobs run these: `webui-script-syntax` (`node --check` per script,
  each reported individually) and `webui-script-lint` (ESLint runtime guard).

The guard found two real issues while being written: an undeclared `NodeFilter`
reference and the WebUI-owned `_clarifyId` / `_clarifySignature` page globals,
which are now explicitly declared rather than silently unresolved.

### One job per check

`0-ci-build-and-test.yml` previously ran release-tool tests plus
`testDebugUnitTest lintDebug assembleDebug` in a single step, so any failure
showed up as one opaque red X. Each gate is now its own job:

`release-tooling-tests`, `webui-script-syntax`, `webui-script-lint`,
`unit-tests`, `android-lint`, `debug-build`, and the existing
`android-ui-smoke` matrix.

Report artifacts were split to match, so a failed run points straight at the
relevant report.

### Job timeouts

Every CI job now declares `timeout-minutes`. Previously none did, so a hung
emulator job could sit on a runner for the six-hour GitHub default.

## Testing

- `python -m unittest discover -s tools/tests -p 'test_*.py'` — 29 passed,
  including new extractor tests and new workflow contract tests that assert each
  gate is its own job, that the combined Gradle invocation is gone, and that
  every job declares a timeout.
- `python tools/extract_webui_scripts.py` then `node --check` over all 8
  extracted scripts — all pass.
- `npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs
  "build/webui-scripts/**/*.js"` — clean.
- Verified extracted line numbers align exactly with the Kotlin source, and that
  a planted `const` reassignment is caught by the guard.
- No Android source or Gradle inputs changed, so Gradle verification was not
  re-run.
